### PR TITLE
add the token verification part

### DIFF
--- a/const.js
+++ b/const.js
@@ -3,3 +3,6 @@ global.DEFAULT_HTTP_LOCATION = 'http://localhost/tr';
 global.DEFAULT_PORT = 3000;
 global.PHANTOM = '/usr/bin/phantom';
 global.RESOURCES_WHITELIST = '/tmp/whitelist.txt';
+global.TOKEN_ENDPOINT = 'https://www.w3.org/Web/publications/authorize';
+global.USERNAME = process.env.USERNAME;
+global.PASSWORD = process.env.PASSWORD;

--- a/functions.js
+++ b/functions.js
@@ -3,7 +3,8 @@ var Http = require('http')
 ,   Fs = require('fs')
 ,   List = require('immutable').List
 ,   Url = require('url')
-,   Specberus = require("../specberus/lib/validator").Specberus;
+,   Specberus = require("../specberus/lib/validator").Specberus
+,   Request = require('request');
 require('./const.js');
 
 // Zip a list with another list
@@ -144,7 +145,7 @@ ThirdPartyChecker.check = function (url) {
       buffer += data;
     });
     phantom.on('close', function() {
-      var consoleout = buffer.replace(global.DEFAULT_SPECBERUS_LOCATION, '', 'g').split("\n");
+      var consoleout = buffer.replace(global.DEFAULT_HTTP_LOCATION, '', 'g').split("\n");
       consoleout.pop();
       resolve(consoleout);
     });
@@ -152,3 +153,25 @@ ThirdPartyChecker.check = function (url) {
 }
 
 exports.ThirdPartyChecker = ThirdPartyChecker;
+
+var TokenChecker = function () {};
+
+TokenChecker.check = function (url, token) {
+  return new Promise(function (resolve) {
+    Request.get({
+      'uri': global.TOKEN_ENDPOINT,
+      'auth': {
+        'user': global.USERNAME,
+        'pass': global.PASSWORD
+      },
+      'qs': {
+        'spec': url,
+        'token': token
+      }
+    }, function (err, res, body) {
+      resolve(JSON.parse(body));
+    });
+  });
+}
+
+exports.TokenChecker = TokenChecker;


### PR DESCRIPTION
The MR is missing:
- the token used by the person requesting the publication
- the shortlink extraction

For the shortlink, it doesn't make sense to wait for specberus to return the metadata. I probably need to extract the shortlink from the document after the download.

Regarding the authentication to the endpoint, I'm using environment variables to make sure we don't mistakenly commit `const.js` with someone's credentials.
