### PR TITLE
Fix #3: Make sure htaccess and PHP files can not be published

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -44,6 +44,14 @@ DocumentDownloader.installAll = function(destsContents) {
   }));
 };
 
+DocumentDownloader.sanitize = function(list) {
+  return list.filter(function (filename) {
+    if (filename.indexOf('.htaccess') !== -1) return false;
+    else if (filename.indexOf('.php') !== -1) return false;
+    else return true;
+  });
+}
+
 DocumentDownloader.fetchAndInstall = function (url, dest, isManifest) {
   var mkdir = Promise.denodeify(Fs.mkdir);
 
@@ -59,9 +67,11 @@ DocumentDownloader.fetchAndInstall = function (url, dest, isManifest) {
     return DocumentDownloader.fetch(url).then(function (content) {
       if (isManifest) {
         var filenames = DocumentDownloader.getFilenames(content);
-        var dests = filenames.set(0, 'Overview.html').map(function (filename) {
-          return dest + '/' + filename;
-        });
+        var dests = DocumentDownloader.sanitize(filenames)
+          .set(0, 'Overview.html')
+          .map(function (filename) {
+            return dest + '/' + filename;
+          });
         var urls = filenames.map(function (filename) {
           return Url.resolve(url, filename);
         });

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,8 @@
 var expect = require("chai").use(require("chai-as-promised")).expect
 ,   Promise = require("promise")
 ,   Fs = require("fs")
-,   List = require("immutable").List
+,   Immutable = require('immutable')
+,   List = Immutable.List
 ;
 
 var DocumentDownloader = require("../functions.js").DocumentDownloader;
@@ -191,6 +192,30 @@ describe('DocumentDownloader', function () {
       ];
 
       expect(DocumentDownloader.getFilenames(manifest).toArray()).to.eql(filenames);
+    });
+  });
+
+  describe('sanitize(list)', function () {
+    it('should be a function', function () {
+      expect(DocumentDownloader.sanitize).to.be.a('function');
+    });
+
+    it('should return an immutable list', function () {
+      expect(DocumentDownloader.sanitize(List())).to.be.an.instanceOf(List);
+    });
+
+    it('should return a list of string', function () {
+      expect(DocumentDownloader.sanitize(List('test')).first()).to.be.a('string');
+    });
+
+    console.log(Immutable.is(DocumentDownloader.sanitize(List.of('allowed_file', '.htaccess')), List.of('allowed_file')));
+
+    it('should filter out .htaccess files', function () {
+      expect(Immutable.is(DocumentDownloader.sanitize(List.of('allowed_file', '.htaccess')), List.of('allowed_file'))).to.be.true;
+    });
+
+    it('should filter out PHP files', function () {
+      expect(Immutable.is(DocumentDownloader.sanitize(List.of('allowed_file', 'not_allowed.php')), List.of('allowed_file'))).to.be.true;
     });
   });
 });


### PR DESCRIPTION
I recognize this implementation is very conservative.

On one hand, we prevent people to publish files like `.htaccess_` or `I.love.the.php.extension` but on the other hand, we make sure files in all subfolders will be filtered, as well as files ending in `.php5` and other derivatives.

I would argue that the 2 files of the previous example are not a good match for TR though.
@tguild, @deniak, @tripu, let me know if I should filter other files/extension. If not, this can be merged.
