### PR TITLE
specberus returns 'process' and not 'processRules'

### DIFF
--- a/app.js
+++ b/app.js
@@ -144,7 +144,7 @@ function publish(metadata) {
           reportEditors: metadata.get('editorIds'),
           informative: false, // FIXME Not always true
           editorDraft: metadata.get('editorsDraft'),
-          processRules: metadata.get('processRules')
+          processRules: metadata.get('process')
         }
       }
     }, function(/*err, httpResponse, body*/){


### PR DESCRIPTION
minor bug correction
