### PR TITLE
TR {install,shortlink update} commands

### DIFF
--- a/const.js
+++ b/const.js
@@ -7,5 +7,5 @@ global.TOKEN_ENDPOINT = 'https://www.w3.org/Web/publications/authorize';
 global.USERNAME = process.env.USERNAME;
 global.PASSWORD = process.env.PASSWORD;
 global.W3C_PUBSYSTEM_URL = '';
-global.TR_INSTALL_CMD = '/bin/cp';
-global.UPDATE_TR_SHORTLINK_CMD = '';
+global.TR_INSTALL_CMD = '/afs/w3.org/pub/WWW/Systems/Mirroring/bin/cvs/cvs-publisher';
+global.UPDATE_TR_SHORTLINK_CMD = '/afs/w3.org/pub/WWW/2002/01/tr-automation/shortlink.sh';


### PR DESCRIPTION
That PR deals with the commands echida should run to commit the document to CVS and to update the shortlinks. We have 2 options:
- use the same script to do both
- use separate scripts

Since we already have the script to update the shortlinks `tr-automation/shortlink.sh`, I would prefer the second option. If we agree on that, I will update the script to make it more fault tolerant. Note, that method will also require the webmaster to install the lockfile package if he wants to run the script manually.
