### PR TITLE
Add a CONTRIBUTING.md file to the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This is the contribution reference of Echidna. Great to have you here. Here are 
 
 ## Talk with us
 
-Talk with us directly on IRC. Here are some [detailed instructions to connect](http://www.w3.org/wiki/IRC). The server is `irc.w3.org` and the corresponding channel is `#pub`.
+Talk with us directly on IRC. Here are some [detailed instructions to connect](http://www.w3.org/wiki/IRC). The server is `irc.w3.org` and the corresponding channel is `#pub`. If you do not have an IRC client on hand, you can log into the [W3C Public IRC Web Client](http://irc.w3.org/).
 
 Discuss the publication workflow and related tools [on the mailing list](http://lists.w3.org/Archives/Public/spec-prod/).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contribute to Echidna
 
+This is the contribution reference of Echidna. Great to have you here. Here are a few ways you can help make this project better!
+
+## Talk to us
+
+Talk to us directly on IRC. Here are some [detailed instructions to connect](http://www.w3.org/wiki/IRC)). The server is `irc.w3.org` and the corresponding channel is `#pub`.
+
+Discuss the publication workflow and related tools [on the mailing list](http://lists.w3.org/Archives/Public/spec-prod/).
+
 ## Report a bug or suggest a feature idea
 
 Start by looking through the [existing bugs](https://github.com/w3c/echidna/issues) to see if this was already asked earlier. You might even find your solution there.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,13 @@ To make sure we are on the same page, you should refer to our [coding style guid
 
 Finally, we value testing a lot. Before committing anything, make sure the test suite still passes by running `npm test` to make sure there is no regression. If you submit a bugfix, try to write tests to reproduce this bug to ensure the same bug will not come up again in the future. And if you submit a new feature, provide tests to ensure the correct behavior of the nominal and edge cases.
 
+A couple of things you should consider before committing and [opening a pull request](https://github.com/w3c/echidna/pulls):
+
+- Regarding your Git commit messages:
+  - Use imperative present tense for commit messages as [suggested in the official documentation](http://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines).
+  - When commiting a bug fix, start your line with "Fix #xx", xx being the issue number. For example: `git commit -m 'Fix #42: Answer the Ultimate Question of Life, The Universe, and Everything'`
+- To ease the merge of pull requests, make sure your branch is up-to-date with `master` when submitting it. Always use `git rebase` instead of `git merge` and `git pull --rebase` instead of `git pull` to avoid merge commits in your submissions.
+
 # Documentation
 
 Documentation can be found on [the wiki](https://github.com/w3c/echidna/wiki). You can help us improving it by adding missing pieces, clarifying unclear parts, or asking us to do that.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,13 @@ Please enter your expected results in this space. When running the steps supplie
 Please enter your actual results in this space. When running the steps supplied above, what actually happened? If showing example output, please surround it with 3 backticks before and after so that it's rendered correctly.
 ```
 
+## Contribute to the code
+
+First of all, thank you very much for offering your help. This is much appreciated.
+
+Before adding a new feature, or submitting a bugfix, please refer to the [existing issues](https://github.com/w3c/echidna/issues) to check if it was already discussed before. If it wasn't, please [create a new one](https://github.com/w3c/echidna/issues/new) so that we can discuss together about it before you start coding. It would be frustrating for everyone if we had to refuse your contribution because we did not share the same opinion!
+
+To make sure we are on the same page, you should refer to our [coding style guide](https://github.com/w3c/echidna/wiki/Coding-style-guide) and [coding practices guide](https://github.com/w3c/echidna/wiki/Coding-practices-guide) before coding.
+
+Finally, we value testing a lot. Before committing anything, make sure the test suite passes by running `npm test` to make sure there is no regression. If you submit a bugfix, try to write tests to reproduce this bug to ensure the same bug will not come up again in the future. And if you submit a new feature, provide tests to ensure the correct behavior of the nominal and edge cases.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This is the contribution reference of Echidna. Great to have you here. Here are 
 
 ## Talk with us
 
-Talk with us directly on IRC. Here are some [detailed instructions to connect](http://www.w3.org/wiki/IRC). The server is `irc.w3.org` and the corresponding channel is `#pub`. If you do not have an IRC client on hand, you can log into the [W3C Public IRC Web Client](http://irc.w3.org/).
+Talk with us directly on IRC. Here are some [detailed instructions to connect](http://www.w3.org/Project/IRC/). The server is `irc.w3.org` and the corresponding channel is `#pub`. If you do not have an IRC client on hand, you can log into the [W3C Public IRC Web Client](http://irc.w3.org/).
 
 Discuss the publication workflow and related tools [on the mailing list](http://lists.w3.org/Archives/Public/spec-prod/).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,4 +49,3 @@ Finally, we value testing a lot. Before committing anything, make sure the test 
 # Documentation
 
 Documentation can be found on [the wiki](https://github.com/w3c/echidna/wiki). You can help us improving it by adding missing pieces, clarifying unclear parts, or asking us to do that.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,23 +17,32 @@ If you do not find anything, you can help report bugs by [filing them here](http
 ```markdown
 ##### Issue Type
 
-Can you help us out in labelling this by telling us what kind of ticket this this? You can say "Bug Report", "Feature Idea" or "Documentation Report".
+Can you help us out in labelling this by telling us what kind of ticket this this?
+You can say "Bug Report", "Feature Idea" or "Documentation Report".
 
 ##### Summary
 
-Please summarize your request in this space. You will earn bonus points for being succinct, but please add enough detail so we can understand the request. Thanks!
+Please summarize your request in this space. You will earn bonus points for being
+succinct, but please add enough detail so we can understand the request. Thanks!
 
 ##### Steps To Reproduce
 
-If this is a bug ticket, please enter the steps you use to reproduce the problem in the space below. If this is a feature request, please enter the steps you would use to use the feature. If an example document is useful, please include its URL.
+If this is a bug ticket, please enter the steps you use to reproduce the problem
+in the space below. If this is a feature request, please enter the steps you would
+use to use the feature. If an example document is useful, please include its URL.
 
 ##### Expected Results
 
-Please enter your expected results in this space. When running the steps supplied above in the previous section, what did you expect to happen? If showing example output, please surround it with 3 backticks before and after so that it's rendered correctly.
+Please enter your expected results in this space. When running the steps supplied
+above in the previous section, what did you expect to happen? If showing example
+output, please surround it with 3 backticks before and after so that it's rendered
+correctly.
 
 ##### Actual Results
 
-Please enter your actual results in this space. When running the steps supplied above, what actually happened? If showing example output, please surround it with 3 backticks before and after so that it's rendered correctly.
+Please enter your actual results in this space. When running the steps supplied
+above, what actually happened? If showing example output, please surround it with
+3 backticks before and after so that it's rendered correctly.
 ```
 
 ## Contribute to the code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contribute to Echidna
+
+## Report a bug or suggest a feature idea
+
+Start by looking through the [existing bugs](https://github.com/w3c/echidna/issues) to see if this was already asked earlier. You might even find your solution there.
+
+If you do not find anything, you can help report bugs by [filing them here](https://github.com/w3c/echidna/issues/new). Please use the following template when doing so:
+
+```markdown
+##### Issue Type
+
+Can you help us out in labelling this by telling us what kind of ticket this this? You can say "Bug Report", "Feature Idea" or "Documentation Report".
+
+##### Summary
+
+Please summarize your request in this space. You will earn bonus points for being succinct, but please add enough detail so we can understand the request. Thanks!
+
+##### Steps To Reproduce
+
+If this is a bug ticket, please enter the steps you use to reproduce the problem in the space below. If this is a feature request, please enter the steps you would use to use the feature. If an example document is useful, please include its URL.
+
+##### Expected Results
+
+Please enter your expected results in this space. When running the steps supplied above in the previous section, what did you expect to happen? If showing example output, please surround it with 3 backticks before and after so that it's rendered correctly.
+
+##### Actual Results
+
+Please enter your actual results in this space. When running the steps supplied above, what actually happened? If showing example output, please surround it with 3 backticks before and after so that it's rendered correctly.
+```
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,15 @@
 
 This is the contribution reference of Echidna. Great to have you here. Here are a few ways you can help make this project better!
 
-## Talk to us
+## Talk with us
 
-Talk to us directly on IRC. Here are some [detailed instructions to connect](http://www.w3.org/wiki/IRC)). The server is `irc.w3.org` and the corresponding channel is `#pub`.
+Talk with us directly on IRC. Here are some [detailed instructions to connect](http://www.w3.org/wiki/IRC). The server is `irc.w3.org` and the corresponding channel is `#pub`.
 
 Discuss the publication workflow and related tools [on the mailing list](http://lists.w3.org/Archives/Public/spec-prod/).
 
 ## Report a bug or suggest a feature idea
 
-Start by looking through the [existing bugs](https://github.com/w3c/echidna/issues) to see if this was already asked earlier. You might even find your solution there.
+Start by looking through the [existing bugs](https://github.com/w3c/echidna/issues) to see if this was already discussed earlier. You might even find your solution there.
 
 If you do not find anything, you can help report bugs by [filing them here](https://github.com/w3c/echidna/issues/new). Please use the following template when doing so:
 
@@ -40,11 +40,11 @@ Please enter your actual results in this space. When running the steps supplied 
 
 First of all, thank you very much for offering your help. This is much appreciated.
 
-Before adding a new feature, or submitting a bugfix, please refer to the [existing issues](https://github.com/w3c/echidna/issues) to check if it was already discussed before. If it wasn't, please [create a new one](https://github.com/w3c/echidna/issues/new) so that we can discuss together about it before you start coding. It would be frustrating for everyone if we had to refuse your contribution because we did not share the same opinion!
+Before adding a new feature or submitting a bugfix, please refer to the [existing issues](https://github.com/w3c/echidna/issues) to check if it was already discussed before. If it wasn't, please [create a new one](https://github.com/w3c/echidna/issues/new) so that we can discuss together about it before you start coding. It would be frustrating for everyone if we had to refuse your contribution because we did not share the same opinion!
 
 To make sure we are on the same page, you should refer to our [coding style guide](https://github.com/w3c/echidna/wiki/Coding-style-guide) and [coding practices guide](https://github.com/w3c/echidna/wiki/Coding-practices-guide) before coding.
 
-Finally, we value testing a lot. Before committing anything, make sure the test suite passes by running `npm test` to make sure there is no regression. If you submit a bugfix, try to write tests to reproduce this bug to ensure the same bug will not come up again in the future. And if you submit a new feature, provide tests to ensure the correct behavior of the nominal and edge cases.
+Finally, we value testing a lot. Before committing anything, make sure the test suite still passes by running `npm test` to make sure there is no regression. If you submit a bugfix, try to write tests to reproduce this bug to ensure the same bug will not come up again in the future. And if you submit a new feature, provide tests to ensure the correct behavior of the nominal and edge cases.
 
 # Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,7 @@ To make sure we are on the same page, you should refer to our [coding style guid
 
 Finally, we value testing a lot. Before committing anything, make sure the test suite passes by running `npm test` to make sure there is no regression. If you submit a bugfix, try to write tests to reproduce this bug to ensure the same bug will not come up again in the future. And if you submit a new feature, provide tests to ensure the correct behavior of the nominal and edge cases.
 
+# Documentation
+
+Documentation can be found on [the wiki](https://github.com/w3c/echidna/wiki). You can help us improving it by adding missing pieces, clarifying unclear parts, or asking us to do that.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,12 @@ A couple of things you should consider before committing and [opening a pull req
   - When commiting a bug fix, start your line with "Fix #xx", xx being the issue number. For example: `git commit -m 'Fix #42: Answer the Ultimate Question of Life, The Universe, and Everything'`
 - To ease the merge of pull requests, make sure your branch is up-to-date with `master` when submitting it. Always use `git rebase` instead of `git merge` and `git pull --rebase` instead of `git pull` to avoid merge commits in your submissions.
 
-# Documentation
+## Documentation
 
 Documentation can be found on [the wiki](https://github.com/w3c/echidna/wiki). You can help us improving it by adding missing pieces, clarifying unclear parts, or asking us to do that.
+
+## Code of Conduct
+
+All contributors to this project agree to follow the [W3C Code of Ethics and Professional Conduct](http://www.w3.org/Consortium/cepc/).
+
+If you want to take action, you can contact W3C Staff as explained in [W3C Procedures](http://www.w3.org/Consortium/pwe/#Procedures).

--- a/README.md
+++ b/README.md
@@ -104,6 +104,4 @@ When the test server is running, the testbed with all drafts will be available i
 
 ## Feedback and contributions
 
-* **File** bugs and suggestions [here on GitHub](https://github.com/w3c/echidna/issues).
-* **Talk to us** on IRC: server `irc.w3.org`, channel `#pub` (here are [detailed instructions to connect](http://www.w3.org/wiki/IRC)).
-* **Discuss** the publication workflow and related tools [on the mailing list](http://lists.w3.org/Archives/Public/spec-prod/).
+Please refer to our [contribution reference](https://github.com/w3c/echidna/blob/master/CONTRIBUTING.md) to learn how to contact us, give feedback, or actively contribute to this project.


### PR DESCRIPTION
This creates a banner every time someone opens an issue or a pull request and gives explanations to contributors.

Along the way I made 2 guides that are pointed by this contribution reference ([Coding style guide](https://github.com/w3c/echidna/wiki/Coding-style-guide) and [Coding practices guide](https://github.com/w3c/echidna/wiki/Coding-practices-guide). I am in the process of finalizing them. I'll be happy to discuss these 2 but I figured it would make everyone save time by starting something and would also guide contributors rather than letting them in the blur. I'll be cleaning things only when everyone is okay with these and try to provide a linter configuration file.

I used *plenty* of references to make something as good as possible.
I gave a lot of love to these documents and I am only willing to improve them :-)
Hurray to free and open source projects! \o/

(I am not assigning anyone here as I'd love feedback from both @deniak and @tripu, but also from @plehegar on the "public-facing" side. I hope this won't create too much of a debate and can be merged on Monday at the same time than when we open the system to the public.)