### PR TITLE
Set up the third party resources checker as lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Echidna is the central piece of software taking care of the new publication work
 
 * [Node.js](http://nodejs.org/)
 * [npm](https://www.npmjs.org/)
-* [PhantomJS](http://phantomjs.org/)
 
 ### npm dependencies
 
@@ -24,6 +23,7 @@ These will be resolved automatically by simply running `npm install` on the dire
 * [Promise](https://github.com/then/promise)
 * [Moment](http://momentjs.com/)
 * [Specberus](https://github.com/w3c/specberus)
+* [`third-party-resources-checker`](https://github.com/dontcallmedom/third-party-resources-checker)
 
 ## How to get it up and running
 

--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ var History = require("./lib/history");
 var JsonHttpService = require("./lib/json-http-service");
 var Publisher = require("./lib/publisher");
 var SpecberusWrapper = require("./functions.js").SpecberusWrapper;
-var ThirdPartyChecker = require("./functions.js").ThirdPartyChecker;
+var ThirdPartyResourcesChecker = require('./lib/third-party-resources-checker');
 var TokenChecker = require("./functions.js").TokenChecker;
 
 // Configuration file
@@ -198,8 +198,9 @@ function orchestrate(spec, token) {
             spec.history = spec.history.add('You are authorized to publish');
 
             spec.jobs['third-party-checker'].status = 'pending';
-            return ThirdPartyChecker.check(httpLocation).then(function (extResources) {
-              if (extResources.length === 0) {
+            return ThirdPartyResourcesChecker.check(httpLocation, global.RESOURCES_WHITELIST)
+            .then(function (extResources) {
+              if (extResources.isEmpty()) {
                 spec.jobs['third-party-checker'].status = 'ok';
                 spec.history = spec.history.add('The document passed the third party checker.');
 

--- a/functions.js
+++ b/functions.js
@@ -59,32 +59,6 @@ SpecberusWrapper.validate = function (url) {
 
 exports.SpecberusWrapper = SpecberusWrapper;
 
-var ThirdPartyChecker = function () {};
-
-ThirdPartyChecker.check = function (url) {
-  var args  = [
-    '../third-party-resources-checker/detect-phantom.js',
-    url,
-    global.RESOURCES_WHITELIST
-  ];
-  var spawn = require('child_process').spawn;
-
-  return new Promise(function (resolve) {
-    var phantom = spawn(global.PHANTOM, args);
-    var buffer = "";
-
-    phantom.stdout.on('data', function (data) { buffer += data; });
-
-    phantom.on('close', function() {
-      var consoleout = buffer.replace(global.DEFAULT_HTTP_LOCATION, '', 'g').split("\n");
-      consoleout.pop();
-      resolve(consoleout);
-    });
-  });
-}
-
-exports.ThirdPartyChecker = ThirdPartyChecker;
-
 var TokenChecker = function () {};
 
 TokenChecker.check = function (url, token) {

--- a/lib/third-party-resources-checker.js
+++ b/lib/third-party-resources-checker.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var List = require('immutable').List;
+var Checker = require('third-party-resources-checker');
+
+var ThirdPartyResourcesChecker = function () {};
+
+ThirdPartyResourcesChecker.check = function (url, whitelist) {
+  return Checker.check(url, whitelist).then(function (result) {
+    return List(result[1]);
+  });
+};
+
+module.exports = ThirdPartyResourcesChecker;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "node-uuid": "1.x.x",
     "promise": "6.x.x",
     "request": "2.x.x",
-    "specberus": "w3c/specberus"
+    "specberus": "w3c/specberus",
+    "third-party-resources-checker": "dontcallmedom/third-party-resources-checker"
   },
   "devDependencies": {
     "chai": "2.x.x",


### PR DESCRIPTION
- Move the checker in the lib folder
- Set up the checker as a npm dependency
- Use the checker's API interface instead of the spawnable command

Merging this will close #86.