### PR TITLE
Code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - "0.10"
 before_script:
   - cp config.js.example config.js
+after_script:
+  - npm run coveralls
 notifications:
   email: false
   irc:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/w3c/echidna.svg?branch=master)](https://travis-ci.org/w3c/echidna)
+[![Coverage Status](https://coveralls.io/repos/w3c/echidna/badge.svg)](https://coveralls.io/r/w3c/echidna)
 [![Dependency Status](https://david-dm.org/w3c/echidna.svg)](https://david-dm.org/w3c/echidna)
 [![devDependency Status](https://david-dm.org/w3c/echidna/dev-status.svg)](https://david-dm.org/w3c/echidna#info=devDependencies)
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "grunt-rev": "0.1.x",
     "grunt-svgmin": "2.x.x",
     "grunt-usemin": "3.x.x",
+    "istanbul": "0.3.x",
     "jscs": "1.x.x",
     "jshint": "2.x.x",
     "load-grunt-tasks": "3.x.x",
@@ -84,6 +85,7 @@
   },
   "scripts": {
     "check-style": "jscs .",
+    "coverage": "istanbul cover _mocha",
     "lint": "jshint .",
     "start": "node app.js",
     "test": "npm run check-style && npm run lint && mocha",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "chai": "2.x.x",
     "chai-as-promised": "4.x.x",
+    "coveralls": "2.x.x",
     "grunt": "0.4.x",
     "grunt-concurrent": "1.x.x",
     "grunt-contrib-clean": "0.6.x",
@@ -86,6 +87,7 @@
   "scripts": {
     "check-style": "jscs .",
     "coverage": "istanbul cover _mocha",
+    "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
     "lint": "jshint .",
     "start": "node app.js",
     "test": "npm run check-style && npm run lint && mocha",


### PR DESCRIPTION
Code coverage can be run via `npm run coverage`.
The coveralls badge is updated after Travis builds.