### PR TITLE
Change behaviour of the testbed to adapt to changes in the API

### DIFF
--- a/test/drafts/frame-timing-2/meta.json
+++ b/test/drafts/frame-timing-2/meta.json
@@ -1,0 +1,14 @@
+{
+"process": "1 August 2014",
+"processURI": "http://www.w3.org/2014/Process-20140801/",
+"editorsDraft": "http://w3c.github.io/navigation-timing/",
+"title":     "Navigation Timing 2",
+"shortname": "navigation-timing-2",
+"status":    "WD",
+"editorIDs": [44357,69474,45188],
+"previousVersion":"http://www.w3.org/TR/2015/WD-navigation-timing-2-20150120/",
+"groupName": "Web Performance Working Group",
+"groupHomepage": "http://www.w3.org/2010/webperf/",
+"groupID": "45211",
+"list": "public-web-perf"
+}

--- a/test/drafts/frame-timing/meta.json
+++ b/test/drafts/frame-timing/meta.json
@@ -1,0 +1,14 @@
+{
+"process": "1 August 2014",
+"processURI": "http://www.w3.org/2014/Process-20140801/",
+"editorsDraft": "http://w3c.github.io/navigation-timing/",
+"title":     "Navigation Timing 2",
+"shortname": "navigation-timing-2",
+"status":    "WD",
+"editorIDs": [44357,69474,45188],
+"previousVersion":"http://www.w3.org/TR/2015/WD-navigation-timing-2-20150120/",
+"groupName": "Web Performance Working Group",
+"groupHomepage": "http://www.w3.org/2010/webperf/",
+"groupID": "45211",
+"list": "public-web-perf"
+}

--- a/test/drafts/navigation-timing/meta.json
+++ b/test/drafts/navigation-timing/meta.json
@@ -1,0 +1,14 @@
+{
+"process": "1 August 2014",
+"processURI": "http://www.w3.org/2014/Process-20140801/",
+"editorsDraft": "http://w3c.github.io/navigation-timing/",
+"title":     "Navigation Timing 2",
+"shortname": "navigation-timing-2",
+"status":    "WD",
+"editorIDs": [44357,69474,45188],
+"previousVersion":"http://www.w3.org/TR/2015/WD-navigation-timing-2-20150120/",
+"groupName": "Web Performance Working Group",
+"groupHomepage": "http://www.w3.org/2010/webperf/",
+"groupID": "45211",
+"list": "public-web-perf"
+}

--- a/test/drafts/resource-timing/meta.json
+++ b/test/drafts/resource-timing/meta.json
@@ -1,0 +1,14 @@
+{
+"process": "1 August 2014",
+"processURI": "http://www.w3.org/2014/Process-20140801/",
+"editorsDraft": "http://w3c.github.io/navigation-timing/",
+"title":     "Navigation Timing 2",
+"shortname": "navigation-timing-2",
+"status":    "WD",
+"editorIDs": [44357,69474,45188],
+"previousVersion":"http://www.w3.org/TR/2015/WD-navigation-timing-2-20150120/",
+"groupName": "Web Performance Working Group",
+"groupHomepage": "http://www.w3.org/2010/webperf/",
+"groupID": "45211",
+"list": "public-web-perf"
+}

--- a/test/drafts/webrtc-stats/Overview.html
+++ b/test/drafts/webrtc-stats/Overview.html
@@ -457,11 +457,11 @@ table.simple {
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">Identifiers for WebRTC's Statistics API</h1>
   
-  <h2 id="w3c-working-draft-06-february-2015"><abbr title="World Wide Web Consortium">W3C</abbr> Working Draft <time property="dcterms:issued" class="dt-published" datetime="2015-02-06">06 February 2015</time></h2>
+  <h2 id="w3c-working-draft-06-february-2015"><abbr title="World Wide Web Consortium">W3C</abbr> Working Draft <time property="dcterms:issued" class="dt-published" datetime="2015-02-06">13 March 2015</time></h2>
   <dl>
     
       <dt>This version:</dt>
-      <dd><a class="u-url" href="http://www.w3.org/TR/2015/WD-webrtc-stats-20150206/">http://www.w3.org/TR/2015/WD-webrtc-stats-20150206/</a></dd>
+      <dd><a class="u-url" href="http://www.w3.org/TR/2015/WD-webrtc-stats-20150313/">http://www.w3.org/TR/2015/WD-webrtc-stats-20150313/</a></dd>
       <dt>Latest published version:</dt>
       <dd><a href="http://www.w3.org/TR/webrtc-stats/">http://www.w3.org/TR/webrtc-stats/</a></dd>
     
@@ -501,10 +501,7 @@ table.simple {
         <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
         <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), 
-        
-        All Rights Reserved.
-        
+        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
         <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
         

--- a/test/drafts/webrtc-stats/meta.json
+++ b/test/drafts/webrtc-stats/meta.json
@@ -1,0 +1,14 @@
+{
+"process": "1 August 2014",
+"processURI": "http://www.w3.org/2014/Process-20140801/",
+"editorsDraft": "http://w3c.github.io/navigation-timing/",
+"title":     "Identifiers for WebRTC's Statistics API",
+"shortname": "webrtc-stats",
+"status":    "WD",
+"editorIDs": [24610, 67103],
+"previousVersion":"http://www.w3.org/TR/2014/WD-webrtc-stats-20141021/",
+"groupName": "Web Real-Time Communications Working Group",
+"groupHomepage": "http://www.w3.org/2011/04/webrtc/",
+"groupID": "47318",
+"list": "public-web-perf"
+}

--- a/test/views/behaviour.js
+++ b/test/views/behaviour.js
@@ -8,8 +8,8 @@
 'use strict';
 
 var JOBS = [
- 'retrieve-resources', 'specberus', 'token-checker', 'third-party-checker',
- 'publish', 'tr-install', 'update-tr-shortlink'
+  'retrieve-resources', 'specberus', 'token-checker',
+  'third-party-checker', 'publish', 'tr-install', 'update-tr-shortlink'
 ];
 
 var log;
@@ -17,6 +17,7 @@ var inspector;
 var allSpecs = [];
 var allJobs = {};
 var allMessages = {};
+var allIDs = {};
 
 function logMessage(message) {
   log = log || $('pre#console');
@@ -52,19 +53,27 @@ function activateActions() {
   });
 
   $('td.status').click(function () {
-    var job = allJobs[$(this).attr('data-spec-id')];
+    retrieveStatus($(this).attr('data-spec-id'));
+    /* var job = allJobs[$(this).attr('data-spec-id')];
     var message = allMessages[$(this).attr('data-spec-id')];
     dumpObject(job);
-    logMessage(message);
+    logMessage(message); */
   });
 
   refresh();
 }
 
+function retrieveStatus(id) {
+  $.get(endpoint() + '/status/?id=' + allIDs[id], function (data) {
+    dumpObject(data);
+    logMessage(data);
+  });
+}
+
 function refresh() {
   $.get(endpoint() + '/status/', function (data) {
     updateJobs(data);
-    window.setTimeout(refresh, $('input#rate')[0].value * 1000);
+    // window.setTimeout(refresh, $('input#rate')[0].value * 1000);
 
     if ($('input#scroll')[0].checked) log[0].scrollTop = log[0].scrollHeight;
   });
@@ -118,11 +127,13 @@ function publishOneSpec(id) {
   params.url = location.href + 'drafts/' + spec.id;
   params.decision = 'foo';
   params.token = '34';
-  $.post(endpoint() + '/request', params, handlePublicationResult);
-}
 
-function handlePublicationResult(data) {
-  logMessage('Response from server:<br />          ' + data);
+  $.post(endpoint() + '/request', params, function (data) {
+    logMessage('Response from server:<br />          ' + data);
+    if (data && 'string' == typeof data) {
+      allIDs[id] = data;
+    }
+  });
 }
 
 function publishAllSpecs(delay) {

--- a/test/views/behaviour.js
+++ b/test/views/behaviour.js
@@ -65,8 +65,8 @@ function activateActions() {
 
 function retrieveStatus(id) {
   $.get(endpoint() + '/status/?id=' + allIDs[id], function (data) {
+    logMessage('Retrieved status of job "' + id + '".');
     dumpObject(data);
-    logMessage(data);
   });
 }
 
@@ -123,7 +123,8 @@ function publishOneSpec(id) {
   var spec = findSpec(id);
   var params = {};
 
-  logMessage('Sumitting spec &ldquo;' + id + '&rdquo; for publication&hellip;');
+  logMessage('Submitting spec &ldquo;' + id +
+    '&rdquo; for publication&hellip;');
   params.url = location.href + 'drafts/' + spec.id;
   params.decision = 'foo';
   params.token = '34';
@@ -142,7 +143,7 @@ function publishAllSpecs(delay) {
   }
   else {
     logMessage(
-      'Sumitting all ' + allSpecs.length + ' specs for publication&hellip;'
+      'Submitting all ' + allSpecs.length + ' specs for publication&hellip;'
     );
 
     for (var i in allSpecs) {

--- a/test/views/index.html
+++ b/test/views/index.html
@@ -24,7 +24,7 @@
             <label>Endpoint<br /><input id="suffix" type="text" value="/api" /></label>
         </form>
 
-        <form class="right">
+        <form class="right hidden">
             <label>Refresh rate (<em>s</em>)<br /><input id="rate" type="number" min="0.1" max="60" step="0.5" value="1.0" /></label>
             <label>Auto-scroll<br /><input id="scroll" type="checkbox" checked /></label>
         </form>

--- a/test/views/style.css
+++ b/test/views/style.css
@@ -48,6 +48,10 @@ form.right {
     float:            right;
 }
 
+form.hidden {
+    display:          none;
+}
+
 form.left > * {
     padding:          0 1rem 0 0;
     display:          inline;


### PR DESCRIPTION
For instance, the method `api/status/` [requires now the ID of a publication job](https://github.com/w3c/echidna/commit/6196cef25da3ad9189282c4d383b883a3f9b5cb5#diff-0364f57fbff2fabbe941ed20c328ef1aR64) as a parameter.