### PR TITLE
Fix express directory for static assets in both environments (prod and dev)

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,6 +39,7 @@ app.use(compression());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(corsHandler);
 app.use(express.static('views'));
+app.use(express.static('assets'));
 
 if (process.env.NODE_ENV === 'production') {
   app.set('views', __dirname + '/dist/views');


### PR DESCRIPTION
This solution isn't too clean, but fixes the issue.

I'll look more into [the API of Express](http://expressjs.com/4x/api.html) and see if it'll be convenient to use Grunt to handle these directories depending on the environment.