### PR TITLE
Add tests to PR #84

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,5 @@
+instrumentation:
+  include-all-sources: true
+  excludes:
+    - "**/bower_components/**"
+    - "Gruntfile.js"

--- a/.jshintignore
+++ b/.jshintignore
@@ -6,3 +6,4 @@ Gruntfile.js
 config.js
 test/views
 test/test.js
+test/test-*.js

--- a/functions.js
+++ b/functions.js
@@ -7,7 +7,7 @@ var Map = require('immutable').Map;
 var Specberus = require('specberus/lib/validator').Specberus;
 require('./config.js');
 
-var SpecberusWrapper = function () {};
+var SpecberusWrapper = {};
 
 SpecberusWrapper.validate = function (url) {
   return new Promise(function (resolve, reject) {
@@ -60,7 +60,7 @@ SpecberusWrapper.version = new Specberus().version;
 
 exports.SpecberusWrapper = SpecberusWrapper;
 
-var TokenChecker = function () {};
+var TokenChecker = {};
 
 TokenChecker.check = function (url, token) {
   return new Promise(function (resolve, reject) {

--- a/lib/document-downloader.js
+++ b/lib/document-downloader.js
@@ -7,9 +7,7 @@ var Promise = require('promise');
 var Url = require('url');
 var Mkdirp = require('mkdirp');
 
-var DocumentDownloader = function () {
-  Object.freeze(this);
-};
+var DocumentDownloader = {};
 
 DocumentDownloader.fetch = function (url) {
   return new Promise(function (resolve, reject) {

--- a/lib/history.js
+++ b/lib/history.js
@@ -11,6 +11,7 @@ var Stack = require('immutable').Stack;
 
 require('../config.js');
 
+// TODO Move this function out to keep the class pure
 function appendToLog(filename, message) {
   if (filename) {
     Fs.appendFile(filename,
@@ -37,6 +38,7 @@ var History = function (facts) {
     global.DEFAULT_LOG_LOCATION + Path.sep +
     meta.name + '-' + meta.version + '.log';
 
+  // TODO Remove side-effect below
   appendToLog(
     this.logFilename,
     '“' + meta.name + '” version “' + meta.version + '” logging here…'
@@ -45,6 +47,14 @@ var History = function (facts) {
   Object.freeze(this);
 };
 
+/**
+ * Adds a fact to the history.
+ * TODO Remove logging side-effect
+ * TODO Make function testable by explicitely dealing with time
+ *
+ * @param {string} fact - The statement to add to the history
+ * @returns {History} The new augmented history
+ */
 History.prototype.add = function (fact) {
   appendToLog(this.logFilename, fact);
   return new History(this.facts.unshift({ time: new Date(), fact: fact }));

--- a/lib/json-http-service.js
+++ b/lib/json-http-service.js
@@ -13,6 +13,10 @@ var Request = require('request');
  * @param {string} pass - The password used for authentication
  */
 var JsonHttpService = function (url, user, pass) {
+  if (typeof this !== 'object') {
+    throw new TypeError('JsonHttpService must be constructed via new');
+  }
+
   if (typeof url !== 'string') throw new TypeError('url must be a string');
   if (typeof user !== 'string') throw new TypeError('user must be a string');
   if (typeof pass !== 'string') throw new TypeError('pass must be a string');

--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -98,6 +98,9 @@ Orchestrator.prototype.runStep = function (step) {
         if (obj.get('status') === 'failure') {
           state = state.set('status', 'failure');
         }
+        else if (obj.get('status') === 'error') {
+          state = state.set('status', 'error');
+        }
 
         if (obj.has('errors')) {
           state = state.setJobErrors(step.get('name'), obj.get('errors'));

--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -1,8 +1,9 @@
 'use strict';
 
 var exec = require('child_process').exec;
-var List = require('immutable').List;
-var Map = require('immutable').Map;
+var Immutable = require('immutable');
+var List = Immutable.List;
+var Map = Immutable.Map;
 var Promise = require('promise');
 
 var DocumentDownloader = require('./document-downloader');

--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -85,7 +85,7 @@ Orchestrator.iterate = function (iteration, condition, handler, t) {
 };
 
 /**
- * @param {Promise.<Map.<string, *>>} step
+ * @param {Map.<string, *>} step
  * @returns {RequestState => List.<Promise.<RequestState>>}
  */
 Orchestrator.prototype.runStep = function (step) {

--- a/lib/request-state.js
+++ b/lib/request-state.js
@@ -97,7 +97,8 @@ function RequestState(status, jobs, history, metadata) {
    * @returns {RequestState} The new state with updated job
    */
   this.setJobStatus = function (jobName, status) {
-    return this.set(
+    if (!this.get('jobs').has(jobName)) return this;
+    else return this.set(
       'jobs',
       this.get('jobs').set(
         jobName,

--- a/lib/request-state.js
+++ b/lib/request-state.js
@@ -53,6 +53,7 @@ function RequestState(status, jobs, history, metadata) {
         return new RequestState(this.status, this.jobs, v, this.metadata);
       case 'metadata':
         return new RequestState(this.status, this.jobs, this.history, v);
+      default: return this;
     }
   };
 

--- a/lib/request-state.js
+++ b/lib/request-state.js
@@ -115,7 +115,8 @@ function RequestState(status, jobs, history, metadata) {
    * @returns {RequestState} The new state with updated job
    */
   this.setJobErrors = function (jobName, errors) {
-    return this.set(
+    if (!this.get('jobs').has(jobName)) return this;
+    else return this.set(
       'jobs',
       this.get('jobs').set(
         jobName,

--- a/lib/request-state.js
+++ b/lib/request-state.js
@@ -85,7 +85,8 @@ function RequestState(status, jobs, history, metadata) {
    * @returns {Boolean} Whether or not the job has started
    */
   this.hasJobStarted = function (jobName) {
-    return this.get('jobs').get(jobName).get('status') === '';
+    if (!this.get('jobs').has(jobName)) return false;
+    else return this.get('jobs').get(jobName).get('status') === '';
   };
 
   /**

--- a/lib/third-party-resources-checker.js
+++ b/lib/third-party-resources-checker.js
@@ -3,9 +3,7 @@
 var List = require('immutable').List;
 var Checker = require('third-party-resources-checker');
 
-var ThirdPartyResourcesChecker = function () {
-  Object.freeze(this);
-};
+var ThirdPartyResourcesChecker = {};
 
 ThirdPartyResourcesChecker.check = function (url, whitelist) {
   return Checker.check(url, whitelist).then(function (result) {

--- a/test/test-history.js
+++ b/test/test-history.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var chai = require('chai');
+var expect = chai.expect;
+
+var History = require('../lib/history');
+
+describe('History', function () {
+  describe('object', function () {
+    it('should be immutable (aka frozen)', function () {
+      expect(Object.isFrozen(new History())).to.be.true;
+    });
+
+    it('should always be called with new', function () {
+      expect(function () { History(); }).to.throw(TypeError);
+    });
+
+    it('should be given an Immutable.Stack as argument', function () {
+      expect(function () { new History(['something']); }).to.throw(TypeError);
+    });
+  });
+});

--- a/test/test-job.js
+++ b/test/test-job.js
@@ -14,6 +14,10 @@ describe('Job', function () {
     it('should be immutable (aka frozen)', function () {
       expect(Object.isFrozen(new Job())).to.be.true;
     });
+
+    it('should always be called with new', function () {
+      expect(function () { Job(); }).to.throw(TypeError);
+    });
   });
 
   describe('get(k)', function () {
@@ -35,7 +39,11 @@ describe('Job', function () {
     it('should successfully update a list of errors', function () {
       var job = new Job().set('errors', new List('error'));
       expect(job.get('errors')).to.equal(new List('error'));
-    })
+    });
+
+    it('should not accept non-string statuses', function () {
+      expect(function () { new Job().set('status', 42); }).to.throw(TypeError);
+    });
 
     it('should not accept Arrays of errors', function () {
       expect(function () {

--- a/test/test-job.js
+++ b/test/test-job.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var chai = require('chai');
+var chaiImmutable = require('chai-immutable');
+var expect = chai.expect;
+var List = require('immutable').List;
+
+var Job = require('../lib/job');
+
+chai.use(chaiImmutable);
+
+describe('Job', function () {
+  describe('object', function () {
+    it('should be immutable (aka frozen)', function () {
+      expect(Object.isFrozen(new Job())).to.be.true;
+    });
+  });
+
+  describe('get(k)', function () {
+    it('should return the status of a job', function () {
+      expect(new Job('status').get('status')).to.equal('status');
+    });
+
+    it('should handle inexisting keys', function () {
+      expect(new Job().get('say-what')).to.be.undefined;
+    });
+  });
+
+  describe('set(k, v)', function () {
+    it('should successfully update a status', function () {
+      var job = new Job().set('status', 'eating-nutella');
+      expect(job.get('status')).to.equal('eating-nutella');
+    });
+
+    it('should successfully update a list of errors', function () {
+      var job = new Job().set('errors', new List('error'));
+      expect(job.get('errors')).to.equal(new List('error'));
+    })
+
+    it('should not accept Arrays of errors', function () {
+      expect(function () {
+        new Job().set('errors', ['error']);
+      }).to.throw(TypeError);
+    });
+  });
+});

--- a/test/test-json-http-service.js
+++ b/test/test-json-http-service.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var chai = require('chai');
+var expect = chai.expect;
+
+var JsonHttpService = require('../lib/json-http-service');
+
+describe('JsonHttpService', function () {
+  describe('object', function () {
+    it('should be immutable (aka frozen)', function () {
+      expect(Object.isFrozen(new JsonHttpService('', '', ''))).to.be.true;
+    });
+
+    it('should always be called with new', function () {
+      expect(function () { JsonHttpService(); }).to.throw(TypeError);
+    });
+
+    it('should be given strings as arguments', function () {
+      [
+        function () { new JsonHttpService(42, '', ''); },
+        function () { new JsonHttpService('', 42, ''); },
+        function () { new JsonHttpService('', '', 42); }
+      ].forEach(function (f) {
+        expect(f).to.throw(TypeError);
+      })
+    })
+  });
+});

--- a/test/test-orchestrator.js
+++ b/test/test-orchestrator.js
@@ -1,12 +1,15 @@
 'use strict';
 
 var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
 var expect = chai.expect;
 var List = require('immutable').List;
 var Promise = require('promise');
 
 var Orchestrator = require('../lib/orchestrator');
 var RequestState = require('../lib/request-state');
+
+chai.use(chaiAsPromised);
 
 describe('Orchestrator', function () {
   describe('hasFinished(state)', function () {

--- a/test/test-orchestrator.js
+++ b/test/test-orchestrator.js
@@ -73,10 +73,19 @@ describe('Orchestrator', function () {
   });
 
   describe('runStep(step)', function () {
+    var dummyRequest = new RequestState().set('jobs', new Map({
+      'dummy': new Job()
+    }));
+
     var resultOk = new Orchestrator().runStep(new Map({
       name: 'dummy',
       promise: Promise.resolve(new Map({ 'status': 'ok' }))
-    }))(new RequestState().set('jobs', new Map({ 'dummy': new Job() })));
+    }))(dummyRequest);
+
+    var resultFailure = new Orchestrator().runStep(new Map({
+      name: 'dummy',
+      promise: Promise.resolve(new Map({ 'status': 'failure' }))
+    }))(dummyRequest);
 
     it('should return a function', function () {
       expect(new Orchestrator().runStep()).to.be.a('function');
@@ -108,6 +117,23 @@ describe('Orchestrator', function () {
       return resultOk.get(1).then(function (state) {
         return expect(state.jobs.get('dummy').status).to.equal('ok');
       });
+    });
+
+    it('should set the second returned state as successful job', function () {
+      return resultOk.get(1).then(function (state) {
+        return expect(state.jobs.get('dummy').status).to.equal('ok');
+      });
+    });
+
+    it('should set the second returned state as failed job', function () {
+      return resultFailure.get(1).then(function (state) {
+        return expect(state.jobs.get('dummy').status).to.equal('failure');
+      });
+    });
+
+    it('should return a failed state when a job fails', function () {
+      return expect(resultFailure.get(1))
+        .to.eventually.have.property('status', 'failure');
     });
   });
 });

--- a/test/test-orchestrator.js
+++ b/test/test-orchestrator.js
@@ -92,6 +92,14 @@ describe('Orchestrator', function () {
       }))
     }))(dummyRequest);
 
+    var resultError = new Orchestrator().runStep(new Map({
+      name: 'dummy',
+      promise: Promise.resolve(new Map({
+        status: 'error',
+        errors: List.of('another error')
+      }))
+    }))(dummyRequest);
+
     it('should return a function', function () {
       expect(new Orchestrator().runStep()).to.be.a('function');
     });
@@ -145,6 +153,23 @@ describe('Orchestrator', function () {
     it('should return a failed state when a job fails', function () {
       return expect(resultFailure.get(1))
         .to.eventually.have.property('status', 'failure');
+    });
+
+    it('should set the second returned state as errored job', function () {
+      return resultError.get(1).then(function (state) {
+        return expect(state.jobs.get('dummy').status).to.equal('error');
+      });
+    });
+
+    it('should return a state with errors when a job errors', function () {
+      return resultError.get(1).then(function (state) {
+        return expect(state.jobs.get('dummy').errors).to.have.size(1);
+      });
+    });
+
+    it('should return an errored state when a job errors', function () {
+      return expect(resultError.get(1))
+        .to.eventually.have.property('status', 'error');
     });
   });
 });

--- a/test/test-orchestrator.js
+++ b/test/test-orchestrator.js
@@ -31,13 +31,19 @@ describe('Orchestrator', function () {
   });
 
   describe('iterate(iteration, condition, handler, t)', function () {
-    // Iteratively increment a value until it reaches 5
-    var result = Orchestrator.iterate(
-      function (n) { return List.of(Promise.resolve(n + 1)); },
-      function (n) { return n >= 5; },
-      function (n) { },
-      0
-    );
+    function incrementUntil(f, n) {
+      return Orchestrator.iterate(
+        function (i) { return List.of(f(i)); },
+        function (i) { return i >= n; },
+        function (i) { },
+        0
+      );
+    }
+
+    // Iteratively increment a value until it reaches 42
+    var result = incrementUntil(function (i) {
+      return Promise.resolve(i + 1);
+    }, 42);
 
     it('should return a promise', function () {
       expect(result).to.be.an.instanceOf(Promise);
@@ -48,7 +54,19 @@ describe('Orchestrator', function () {
     });
 
     it('should properly compute the example value', function () {
-      return expect(result).to.eventually.equal(5);
+      return expect(result).to.eventually.equal(42);
+    });
+
+    it('should properly iterate over an asynchronous computation', function () {
+      function incrementDelay(n) {
+        return new Promise(function (resolve) {
+          setTimeout(function () { resolve(n + 1); }, 25);
+        });
+      }
+
+      // Iteratively increment a value until it 5 with a delay between each increment
+      var resultDelay = incrementUntil(incrementDelay, 4);
+      return expect(resultDelay).to.eventually.equal(4);
     });
   });
 });

--- a/test/test-orchestrator.js
+++ b/test/test-orchestrator.js
@@ -4,6 +4,7 @@ var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
 var expect = chai.expect;
 var List = require('immutable').List;
+var Map = require('immutable').Map;
 var Promise = require('promise');
 
 var Orchestrator = require('../lib/orchestrator');
@@ -67,6 +68,33 @@ describe('Orchestrator', function () {
       // Iteratively increment a value until it 5 with a delay between each increment
       var resultDelay = incrementUntil(incrementDelay, 4);
       return expect(resultDelay).to.eventually.equal(4);
+    });
+  });
+
+  describe('runStep(step)', function () {
+    var resultOk = new Orchestrator().runStep(new Map({
+      name: 'dummy',
+      promise: Promise.resolve(new Map({ 'status': 'ok' }))
+    }))(new RequestState());
+
+    it('should return a function', function () {
+      expect(new Orchestrator().runStep()).to.be.a('function');
+    });
+
+    it('should return a list with 2 elements', function () {
+      expect(resultOk).to.be.an.instanceOf(List).and.to.have.size(2);
+    });
+
+    it('should return Promises', function () {
+      resultOk.forEach(function (promise) {
+        expect(promise).to.be.an.instanceOf(Promise);
+      });
+    });
+
+    it('should promise a bunch of RequestState objects', function () {
+      return Promise.all(resultOk.map(function (promise) {
+        return expect(promise).to.be.eventually.an.instanceOf(RequestState);
+      }).toArray());
     });
   });
 });

--- a/test/test-orchestrator.js
+++ b/test/test-orchestrator.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var chai = require('chai');
+var expect = chai.expect;
+
+var Orchestrator = require('../lib/orchestrator');
+var RequestState = require('../lib/request-state');
+
+describe('Orchestrator', function () {
+  describe('hasFinished(state)', function () {
+    it('should be true when the passing state is successful', function () {
+      expect(Orchestrator.hasFinished(new RequestState('success'))).to.be.true;
+    });
+
+    it('should be true when the passing state has failed', function () {
+      expect(Orchestrator.hasFinished(new RequestState('error'))).to.be.true;
+    });
+
+    it('should be true when the passing state has crashed', function () {
+      expect(Orchestrator.hasFinished(new RequestState('failure'))).to.be.true;
+    });
+
+    it('should be false when the passing state is pending', function () {
+      expect(Orchestrator.hasFinished(new RequestState('started'))).to.be.false;
+    });
+  });
+});

--- a/test/test-orchestrator.js
+++ b/test/test-orchestrator.js
@@ -2,6 +2,8 @@
 
 var chai = require('chai');
 var expect = chai.expect;
+var List = require('immutable').List;
+var Promise = require('promise');
 
 var Orchestrator = require('../lib/orchestrator');
 var RequestState = require('../lib/request-state');
@@ -22,6 +24,28 @@ describe('Orchestrator', function () {
 
     it('should be false when the passing state is pending', function () {
       expect(Orchestrator.hasFinished(new RequestState('started'))).to.be.false;
+    });
+  });
+
+  describe('iterate(iteration, condition, handler, t)', function () {
+    // Iteratively increment a value until it reaches 5
+    var result = Orchestrator.iterate(
+      function (n) { return List.of(Promise.resolve(n + 1)); },
+      function (n) { return n >= 5; },
+      function (n) { },
+      0
+    );
+
+    it('should return a promise', function () {
+      expect(result).to.be.an.instanceOf(Promise);
+    });
+
+    it('should promise an output of same type than input', function () {
+      return expect(result).to.eventually.be.a('number');
+    });
+
+    it('should properly compute the example value', function () {
+      return expect(result).to.eventually.equal(5);
     });
   });
 });

--- a/test/test-request-state.js
+++ b/test/test-request-state.js
@@ -67,4 +67,18 @@ describe('RequestState', function () {
       expect(r.hasJobStarted('inexisting')).to.be.false;
     });
   });
+
+  describe('setJobStatus(jobName, status)', function () {
+    var r = new RequestState().set('jobs', new Map({ 'dummy': new Job() }));
+
+    it('should update the status of a specific job', function () {
+      var state = r.setJobStatus('dummy', 'foo');
+      expect(state.get('jobs').get('dummy').get('status')).to.equal('foo');
+    });
+
+    it('should handle inexisting jobs', function () {
+      var state = r.setJobStatus('inexisting');
+      expect(state).to.equal(r);
+    });
+  });
 });

--- a/test/test-request-state.js
+++ b/test/test-request-state.js
@@ -3,8 +3,11 @@
 var chai = require('chai');
 var chaiImmutable = require('chai-immutable');
 var expect = chai.expect;
-var List = require('immutable').List;
+var Immutable = require('immutable');
+var List = Immutable.List;
+var Map = Immutable.Map;
 
+var Job = require('../lib/job');
 var RequestState = require('../lib/request-state');
 
 chai.use(chaiImmutable);
@@ -35,6 +38,33 @@ describe('RequestState', function () {
     it('should handle inexisting keys', function () {
       var state = new RequestState();
       expect(state.set('foo', 'bar')).to.equal(state);
+    });
+  });
+
+  describe('addToHistory(fact)', function () {
+    it('should return a new State with one more fact', function () {
+      var state = new RequestState().addToHistory('Some random fact');
+      // TODO Improve test when History is refactored
+      expect(state.get('history').facts).to.have.size(1);
+    });
+  });
+
+  // TODO Rename hasJobStarted() or change behavior as it is currently misleading
+  describe('hasJobStarted(jobName)', function () {
+    var r = new RequestState();
+
+    it('should be true when the job has not started', function () {
+      var state = r.set('jobs', new Map({ 'dummy': new Job('') }));
+      expect(state.hasJobStarted('dummy')).to.be.true;
+    });
+
+    it('should be false when the job has started', function () {
+      var state = r.set('jobs', new Map({ 'dummy': new Job('ok') }));
+      expect(state.hasJobStarted('dummy')).to.be.false;
+    });
+
+    it('should handle inexisting jobs', function () {
+      expect(r.hasJobStarted('inexisting')).to.be.false;
     });
   });
 });

--- a/test/test-request-state.js
+++ b/test/test-request-state.js
@@ -31,5 +31,10 @@ describe('RequestState', function () {
       var state = new RequestState().set('status', 'yawning');
       expect(state.get('status')).to.equal('yawning');
     });
+
+    it('should handle inexisting keys', function () {
+      var state = new RequestState();
+      expect(state.set('foo', 'bar')).to.equal(state);
+    });
   });
 });

--- a/test/test-request-state.js
+++ b/test/test-request-state.js
@@ -81,4 +81,18 @@ describe('RequestState', function () {
       expect(state).to.equal(r);
     });
   });
+
+  describe('setJobErrors(jobName, errors)', function () {
+    var r = new RequestState().set('jobs', new Map({ 'dummy': new Job() }));
+
+    it('should update the status of a specific job', function () {
+      var state = r.setJobErrors('dummy', List.of('error'));
+      expect(state.get('jobs').get('dummy').get('errors')).to.have.size(1);
+    });
+
+    it('should handle inexisting jobs', function () {
+      var state = r.setJobErrors('inexisting');
+      expect(state).to.equal(r);
+    });
+  });
 });

--- a/test/test-request-state.js
+++ b/test/test-request-state.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var chai = require('chai');
+var chaiImmutable = require('chai-immutable');
+var expect = chai.expect;
+var List = require('immutable').List;
+
+var RequestState = require('../lib/request-state');
+
+chai.use(chaiImmutable);
+
+describe('RequestState', function () {
+  describe('object', function () {
+    it('should be immutable (aka frozen)', function () {
+      expect(Object.isFrozen(new RequestState())).to.be.true;
+    });
+  });
+
+  describe('get(k)', function () {
+    it('should return the status of the request', function () {
+      expect(new RequestState('status').get('status')).to.equal('status');
+    });
+
+    it('should handle inexisting keys', function () {
+      expect(new RequestState().get('say-what')).to.be.undefined;
+    });
+  });
+
+  describe('set(k, v)', function () {
+    it('should successfully update a status', function () {
+      var state = new RequestState().set('status', 'yawning');
+      expect(state.get('status')).to.equal('yawning');
+    });
+  });
+});

--- a/test/test-request-state.js
+++ b/test/test-request-state.js
@@ -13,86 +13,78 @@ var RequestState = require('../lib/request-state');
 chai.use(chaiImmutable);
 
 describe('RequestState', function () {
+  var state = new RequestState('something', new Map({ 'dummy': new Job() }));
+
   describe('object', function () {
     it('should be immutable (aka frozen)', function () {
-      expect(Object.isFrozen(new RequestState())).to.be.true;
+      expect(Object.isFrozen(state)).to.be.true;
     });
   });
 
   describe('get(k)', function () {
     it('should return the status of the request', function () {
-      expect(new RequestState('status').get('status')).to.equal('status');
+      expect(state.get('status')).to.equal('something');
     });
 
     it('should handle inexisting keys', function () {
-      expect(new RequestState().get('say-what')).to.be.undefined;
+      expect(state.get('say-what')).to.be.undefined;
     });
   });
 
   describe('set(k, v)', function () {
     it('should successfully update a status', function () {
-      var state = new RequestState().set('status', 'yawning');
-      expect(state.get('status')).to.equal('yawning');
+      var newState = state.set('status', 'yawning');
+      expect(newState.get('status')).to.equal('yawning');
     });
 
     it('should handle inexisting keys', function () {
-      var state = new RequestState();
       expect(state.set('foo', 'bar')).to.equal(state);
     });
   });
 
   describe('addToHistory(fact)', function () {
     it('should return a new State with one more fact', function () {
-      var state = new RequestState().addToHistory('Some random fact');
+      var newState = state.addToHistory('Some random fact');
       // TODO Improve test when History is refactored
-      expect(state.get('history').facts).to.have.size(1);
+      expect(newState.get('history').facts).to.have.size(1);
     });
   });
 
   // TODO Rename hasJobStarted() or change behavior as it is currently misleading
   describe('hasJobStarted(jobName)', function () {
-    var r = new RequestState();
-
     it('should be true when the job has not started', function () {
-      var state = r.set('jobs', new Map({ 'dummy': new Job('') }));
       expect(state.hasJobStarted('dummy')).to.be.true;
     });
 
     it('should be false when the job has started', function () {
-      var state = r.set('jobs', new Map({ 'dummy': new Job('ok') }));
-      expect(state.hasJobStarted('dummy')).to.be.false;
+      var newState = state.set('jobs', new Map({ 'dummy': new Job('ok') }));
+      expect(newState.hasJobStarted('dummy')).to.be.false;
     });
 
     it('should handle inexisting jobs', function () {
-      expect(r.hasJobStarted('inexisting')).to.be.false;
+      expect(state.hasJobStarted('inexisting')).to.be.false;
     });
   });
 
   describe('setJobStatus(jobName, status)', function () {
-    var r = new RequestState().set('jobs', new Map({ 'dummy': new Job() }));
-
     it('should update the status of a specific job', function () {
-      var state = r.setJobStatus('dummy', 'foo');
-      expect(state.get('jobs').get('dummy').get('status')).to.equal('foo');
+      var newState = state.setJobStatus('dummy', 'foo');
+      expect(newState.get('jobs').get('dummy').get('status')).to.equal('foo');
     });
 
     it('should handle inexisting jobs', function () {
-      var state = r.setJobStatus('inexisting');
-      expect(state).to.equal(r);
+      expect(state.setJobStatus('inexisting')).to.equal(state);
     });
   });
 
   describe('setJobErrors(jobName, errors)', function () {
-    var r = new RequestState().set('jobs', new Map({ 'dummy': new Job() }));
-
     it('should update the status of a specific job', function () {
-      var state = r.setJobErrors('dummy', List.of('error'));
-      expect(state.get('jobs').get('dummy').get('errors')).to.have.size(1);
+      var newState = state.setJobErrors('dummy', List.of('error'));
+      expect(newState.get('jobs').get('dummy').get('errors')).to.have.size(1);
     });
 
     it('should handle inexisting jobs', function () {
-      var state = r.setJobErrors('inexisting');
-      expect(state).to.equal(r);
+      expect(state.setJobErrors('inexisting')).to.equal(state);
     });
   });
 });


### PR DESCRIPTION
64 tests before, 112 tests after (**48 new tests**). Most of them are dead simple but that will help detect issues when refactoring small or big portions.

The scary part is the code coverage: it is marked as **98%** at the moment, while it will go down to **62%** when this PR is merged. However, do not get fooled, the overall coverage *does* increases with this PR.
This comes from the fact that this PR asks [Istanbul](https://github.com/gotwarlost/istanbul) to cover all source files where it used to take into account only files that were traversed by the tests. It means that source files that were absolutely not tested... were not counted! Not very accurate.

A question for @tripu: should we add `app.js` to the files ignored by the coverage? On one hand it seems like cheating, on the other hand we will *never* be able to test it using [Mocha](http://mochajs.org/) and our test suite...