### PR TITLE
Update expected errors in tests, post w3c/specberus#173

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -371,7 +371,7 @@ describe('SpecberusWrapper', function () {
 
     it('should return an error property that is an empty list', function () {
       return expect(content).that.eventually.has.property('errors')
-        .that.is.empty;
+        .that.has.size(1);
     });
 
     it('should promise an object with a metadata property', function () {
@@ -446,7 +446,7 @@ describe('SpecberusWrapper', function () {
 
     it('should return an error property that has 2 errors', function () {
       return expect(content).that.eventually.has.property('errors')
-        .that.has.size(2);
+        .that.has.size(3);
     });
   });
 
@@ -457,7 +457,7 @@ describe('SpecberusWrapper', function () {
 
     it('should return an error property that has no errors', function () {
       return expect(content).that.eventually.has.property('errors')
-        .that.is.empty;
+        .that.has.size(1);
     });
   });
 });


### PR DESCRIPTION
w3c/specberus#173 added a few new possible errors; among them, [`latest-is-not-previous`](https://github.com/w3c/specberus/pull/173/files#diff-09f641a52baf89d6d1785acc66dafe97R172).

These three drafts used by the test suite are affected:

* `navigation-timing-2`
* `nav-csserror`
* `nav-csswarning`

This PR updates (adds one to) the total count of errors expected by mocha for these three test specs, thus fixing the result of the test suite.