### PR TITLE
Fix #160: Make sure filenames and destination files lists match after sanitizing

### DIFF
--- a/lib/document-downloader.js
+++ b/lib/document-downloader.js
@@ -48,15 +48,20 @@ DocumentDownloader.installAll = function (destsContents) {
   }));
 };
 
-DocumentDownloader.sanitize = function (list) {
-  return list.filter(function (filename) {
-    if (filename.toLowerCase().indexOf('.htaccess') !== -1) return false;
-    else if (filename.toLowerCase().indexOf('.php') !== -1) return false;
-    else return true;
-  });
+/**
+ * Checks if a given filename is allowed to be published by the system.
+ *
+ * @param {string} filename - The filename to check against
+ * @returns {boolean} `true` if the filename is allowed, `false` otherwise
+ */
+DocumentDownloader.isAllowed = function isAllowed(filename) {
+  if (filename.toLowerCase().indexOf('.htaccess') !== -1) return false;
+  else if (filename.toLowerCase().indexOf('.php') !== -1) return false;
+  else return true;
 };
 
 DocumentDownloader.fetchAndInstall = function (url, dest) {
+  var _ = DocumentDownloader; // Class name shortener
   var mkdir = Promise.denodeify(Fs.mkdir);
 
   return new Promise(function (resolve) {
@@ -64,35 +69,36 @@ DocumentDownloader.fetchAndInstall = function (url, dest) {
   }).then(function (pathExists) {
     if (!pathExists) return mkdir(dest);
   }).then(function () {
-    return DocumentDownloader.fetch(url).then(function (content) {
+    return _.fetch(url).then(function (content) {
       var contentUtf8 = content.toString('utf8');
 
       if (contentUtf8.trim().charAt(0) !== '<') {
-        var filenames = DocumentDownloader.getFilenames(contentUtf8);
-        var dests = DocumentDownloader.sanitize(filenames)
+        var filenames = _.getFilenames(contentUtf8).filter(_.isAllowed);
+
+        var dests = filenames
           .set(0, 'Overview.html')
-          .map(function (filename) {
-            return dest + '/' + filename;
-          });
+          .map(function (filename) { return dest + '/' + filename; });
+
         var urls = filenames.map(function (filename) {
           // If an entry in the manifest had a space in it,
           // we assume it needs to be built from the spec-generator.
           // See https://github.com/w3c/spec-generator
           var specGeneratorComp = filename.split(' ');
           var absUrl = Url.resolve(url, specGeneratorComp[0]);
+
           if (specGeneratorComp.length === 2) {
-            return global.SPEC_GENERATOR + '?type=' +
-                     encodeURIComponent(specGeneratorComp[1]) +
-                     '&url=' + encodeURIComponent(absUrl);
+            return global.SPEC_GENERATOR +
+              '?type=' + encodeURIComponent(specGeneratorComp[1]) +
+              '&url=' + encodeURIComponent(absUrl);
           }
           return absUrl;
         });
 
-        return DocumentDownloader.fetchAll(urls).then(function (contents) {
-          return DocumentDownloader.installAll(dests.zip(contents));
+        return _.fetchAll(urls).then(function (contents) {
+          return _.installAll(dests.zip(contents));
         });
       }
-      else return DocumentDownloader.install(dest + '/Overview.html', content);
+      else return _.install(dest + '/Overview.html', content);
     });
   });
 };

--- a/test/test.js
+++ b/test/test.js
@@ -315,30 +315,25 @@ describe('DocumentDownloader', function () {
     });
   });
 
-  describe('sanitize(list)', function () {
+  describe('isAllowed(filename)', function () {
     it('should be a function', function () {
-      expect(DocumentDownloader.sanitize).to.be.a('function');
+      expect(DocumentDownloader.isAllowed).to.be.a('function');
     });
 
-    it('should return an immutable list', function () {
-      expect(DocumentDownloader.sanitize(new List())).to.be.an.instanceOf(List);
+    it('should return a boolean', function () {
+      expect(DocumentDownloader.isAllowed('')).to.be.a('boolean');
     });
 
-    it('should return a list of string', function () {
-      expect(DocumentDownloader.sanitize(List.of('test')).first())
-        .to.be.a('string');
+    it('should filter not filter out HTML files', function () {
+      expect(DocumentDownloader.isAllowed('index.html')).to.be.true;
     });
 
     it('should filter out .htaccess files', function () {
-      expect(DocumentDownloader.sanitize(List.of('allowed_file', '.htaccess')))
-        .to.equal(List.of('allowed_file'));
+      expect(DocumentDownloader.isAllowed('.htaccess')).to.be.false;
     });
 
     it('should filter out PHP files', function () {
-      expect(DocumentDownloader.sanitize(List.of(
-        'allowed_file',
-        'not_allowed.php'
-      ))).to.equal(List.of('allowed_file'));
+      expect(DocumentDownloader.isAllowed('not_allowed.php')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
The bug fix is essentially at [line 78](https://github.com/w3c/echidna/pull/161/files#diff-bac32d994d58faa28bb71801bbf1de35R78), but I cleaned up some other things around and added a docstring (yes, just for one function of the file :p).