### PR TITLE
Update navigation-timing-2 draft and fix test

### DIFF
--- a/test/drafts/navigation-timing-2/meta.json
+++ b/test/drafts/navigation-timing-2/meta.json
@@ -6,7 +6,7 @@
 "shortname": "navigation-timing-2",
 "status":    "WD",
 "editorIDs": [44357,69474,45188],
-"previousVersion":"http://www.w3.org/TR/2015/WD-navigation-timing-2-20150120/",
+"previousVersion":"http://www.w3.org/TR/2015/WD-navigation-timing-2-20150422/",
 "groupName": "Web Performance Working Group",
 "groupHomepage": "http://www.w3.org/2010/webperf/",
 "groupID": "45211",

--- a/test/test.js
+++ b/test/test.js
@@ -371,7 +371,7 @@ describe('SpecberusWrapper', function () {
 
     it('should return an error property that is an empty list', function () {
       return expect(content).that.eventually.has.property('errors')
-        .that.has.size(1);
+        .that.is.empty;
     });
 
     it('should promise an object with a metadata property', function () {


### PR DESCRIPTION
Kind of related to https://github.com/w3c/echidna/pull/159#issuecomment-95673615

@plehegar, any idea on how we could avoid this situation in the future, by chance?