### PR TITLE
Mail notifications: fix one bug, and improve subject lines and messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+
 # Contribute to Echidna
 
 This is the contribution reference of Echidna. Great to have you here. Here are a few ways you can help make this project better!
@@ -11,6 +12,11 @@ Discuss the publication workflow and related tools [on the mailing list](http://
 ## Report a bug or suggest a feature idea
 
 Start by looking through the [existing bugs](https://github.com/w3c/echidna/issues) to see if this was already discussed earlier. You might even find your solution there.
+
+**NB:** as of today, Echidna and Specberus are developed, tested and deployed using [Node.js](http://nodejs.org/) `v0.12.0`
+and [npm](https://www.npmjs.org/) `2.5.1`.
+When reporting bugs, please make sure you can reproduce them with this recommended setup.
+Also, remember to update npm dependencies often.
 
 If you do not find anything, you can help report bugs by [filing them here](https://github.com/w3c/echidna/issues/new). Please use the following template when doing so:
 
@@ -71,3 +77,4 @@ Documentation can be found on [the wiki](https://github.com/w3c/echidna/wiki). Y
 All contributors to this project agree to follow the [W3C Code of Ethics and Professional Conduct](http://www.w3.org/Consortium/cepc/).
 
 If you want to take action, you can contact W3C Staff as explained in [W3C Procedures](http://www.w3.org/Consortium/pwe/#Procedures).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 # Contribute to Echidna
 
 This is the contribution reference of Echidna. Great to have you here. Here are a few ways you can help make this project better!
@@ -77,4 +76,3 @@ Documentation can be found on [the wiki](https://github.com/w3c/echidna/wiki). Y
 All contributors to this project agree to follow the [W3C Code of Ethics and Professional Conduct](http://www.w3.org/Consortium/cepc/).
 
 If you want to take action, you can contact W3C Staff as explained in [W3C Procedures](http://www.w3.org/Consortium/pwe/#Procedures).
-

--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ Please [see the wiki](https://github.com/w3c/echidna/wiki) for how to use Echidn
 To run Echidna, you need to install [Node.js](http://nodejs.org/) first.
 This will install [npm](https://www.npmjs.org/) at the same time, which is required as well.
 
-**NB:** as of today, Echidna and Specberus are developed, tested and deployed using [Node.js](http://nodejs.org/) `v0.12.0`
-and [npm](https://www.npmjs.org/) `2.5.1`.
-When reporting bugs, please make sure you can reproduce them with this recommended setup.
-Also, remember to update npm dependencies often.
-
 Then run the following commands with your favorite terminal:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Please [see the wiki](https://github.com/w3c/echidna/wiki) for how to use Echidn
 To run Echidna, you need to install [Node.js](http://nodejs.org/) first.
 This will install [npm](https://www.npmjs.org/) at the same time, which is required as well.
 
+**NB:** as of today, Echidna and Specberus are developed, tested and deployed using [Node.js](http://nodejs.org/) `v0.12.0`
+and [npm](https://www.npmjs.org/) `2.5.1`.
+When reporting bugs, please make sure you can reproduce them with this recommended setup.
+Also, remember to update npm dependencies often.
+
 Then run the following commands with your favorite terminal:
 
 ```bash

--- a/app.js
+++ b/app.js
@@ -142,7 +142,8 @@ app.post('/api/request', function (req, res) {
         cmd += ' \'' + JSON.stringify(state, null, 2) + '\'';
       }
       else {
-        cmd += ' \'Echidna ' + meta.version + '; Specberus ' + SpecberusWrapper.version + '\'';
+        cmd += ' \'Echidna ' + meta.version +
+          '; Specberus ' + SpecberusWrapper.version + '\'';
       }
 
       console.log('[' + state.get('status').toUpperCase() + '] ' + url);

--- a/app.js
+++ b/app.js
@@ -141,6 +141,9 @@ app.post('/api/request', function (req, res) {
       if (state.get('status') === 'error') {
         cmd += ' \'' + JSON.stringify(state, null, 2) + '\'';
       }
+      else {
+        cmd += ' \'Echidna ' + meta.version + '; Specberus ' + SpecberusWrapper.version + '\'';
+      }
 
       console.log('[' + state.get('status').toUpperCase() + '] ' + url);
       exec(cmd, function (err, _, stderr) { if (err) console.error(stderr); });

--- a/app.js
+++ b/app.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 console.log('Launching…');
@@ -188,4 +187,3 @@ console.log(
   ' and listening on port ' + port +
   '. The server time is ' + new Date().toLocaleTimeString() + '.'
 );
-

--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+
 'use strict';
 
 console.log('Launching…');
@@ -135,7 +136,7 @@ app.post('/api/request', function (req, res) {
       requests[id].state
     ).then(function (state) {
       var cmd = global.SENDMAIL + ' ' + state.get('status').toUpperCase() +
-        ' ' + global.MAILING_LIST + url;
+        ' ' + global.MAILING_LIST + ' ' + url;
 
       if (state.get('status') === 'error') {
         cmd += ' \'' + JSON.stringify(state, null, 2) + '\'';
@@ -183,3 +184,4 @@ console.log(
   ' and listening on port ' + port +
   '. The server time is ' + new Date().toLocaleTimeString() + '.'
 );
+

--- a/sendmail.sh
+++ b/sendmail.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 STATUS=$1

--- a/sendmail.sh
+++ b/sendmail.sh
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 
 STATUS=$1
@@ -6,18 +7,19 @@ URI=$3
 RESULT=$4
 
 if [ $# -lt 3 ]; then
-    echo "`basename $0` [SUCCESS|ERROR] DESTINATION URI [RESULT]"
-    echo "`basename $0` SUCCESS foobar@w3.org http://www.w3.org/TR/YYYY/WD-shortname-YYYYMMDD"
+    echo "`basename $0` [SUCCESS|ERROR] DESTINATION URI RESULT"
+    echo "`basename $0` SUCCESS foobar@w3.org http://www.w3.org/TR/YYYY/WD-shortname-YYYYMMDD 'Echidna 1.2.0; Specberus 1.1.0'"
+    echo "`basename $0` ERROR foobar@w3.org http://www.w3.org/TR/YYYY/WD-shortname-YYYYMMDD 'Error: foo is wrong, bar is invalid…'"
     exit 1
 fi
 
 if [ "SUCCESS" == "$STATUS" ]; then
-    SUBJECT="[W3C Publication] $URI has been published on http://www.w3.org/TR/"
-    BODY="On `date -u`, $URI has been published by the W3C automated publication system.
+    SUBJECT="[W3C Publication] Success: $URI"
+    BODY="On `date -u`, $URI has been published by the W3C automated publication system ($RESULT).
 
 If you believe there's an error, please contact webreq@w3.org."
 elif [ "ERROR" == "$STATUS" ]; then
-    SUBJECT="[W3C Publication] Publication of $URI failed"
+    SUBJECT="[W3C Publication] Failed: $URI"
     BODY="On `date -u`, the request to publish $URI failed. See details below.
 
 $RESULT"


### PR DESCRIPTION
(I know&hellip; these are different issues, and should be different PRs. I use `tripu/miscellanea` for bunches of trivial fixes that usually can be safely processed together. It was only later that I saw that was not the case this time. If anything here is controversial, I'm happy to split into different PRs, of course :¬)

* Fix [bug](https://github.com/w3c/echidna/commit/36c3fc75f2173a8d2b7fb8052ed31bec8ef63369#diff-0364f57fbff2fabbe941ed20c328ef1aR147): missing space between command-line arguments sent to the *sendmail* script.
* Two improvements to notifications sent to the mailing list:
  * Subject line more compact, easier to parse quickly when browsing mail archives, or when only the beginnings of subject lines are visible, eg on a narrow mail client:
  ```
[W3C Publication] Success: <URL>
[W3C Publication] Failed: <URL>
[W3C Publication] Success: <URL>
[W3C Publication] Success: <URL>
[W3C Publication] Failed: <URL>
[W3C Publication] Failed: <URL>
[W3C Publication] Success: <URL>
[W3C Publication] Success: <URL>
[W3C Publication] Success: <URL>
[W3C Publication] Failed: <URL>
```
  * For successful publications, include versions of Echidna and Specberus too. This means that the 4th argument of the script is mandatory now, too.
* Added notes for contributors about which versions of Node.js and nps we use now.
