### PR TITLE
Fix express directory for static assets

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,17 +30,7 @@ var argResultLocation = process.argv[5] || global.DEFAULT_RESULT_LOCATION;
 app.use(compression());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(corsHandler);
-app.use(express.static('views'));
 app.use(express.static('assets'));
-
-if (process.env.NODE_ENV === 'production') {
-  app.set('views', __dirname + '/dist/views');
-  app.use(express.static(__dirname + '/dist/assets'));
-}
-else {
-  app.set('views', __dirname + '/views');
-  app.use(express.static(__dirname + '/assets'));
-}
 
 // Index Page
 app.get('/', function (request, response) {


### PR DESCRIPTION
Because `NODE_ENV` is set in the code only [in `test/test.js`](https://github.com/w3c/echidna/blob/master/test/test.js#L4) (to `'dev'`), the expression `process.env.NODE_ENV === 'production'` was always `false`. Thus the first clause of the condition never executed¹.

Apart from that, [the default value of the app setting `view` is `process.cwd() + '/views'`](http://expressjs.com/4x/api.html#app.set), so there is no need to set it manually. Only the directory for static content `assets/` needs to be set, as described [here](http://expressjs.com/starter/static-files.html). No need to use `dist/`directories either as we're not using Grunt tasks for configuration management.

-- 
¹ `NODE_ENV` is still set to `production` manually in the command line when deploying, as described in the [internal docs](https://www.w3.org/Systems/Publishing/new-workflow#start).