### PR TITLE
Update navigation-timing-2 draft to reflect latest version (again)

### DIFF
--- a/test/drafts/navigation-timing-2/meta.json
+++ b/test/drafts/navigation-timing-2/meta.json
@@ -6,7 +6,7 @@
 "shortname": "navigation-timing-2",
 "status":    "WD",
 "editorIDs": [44357,69474,45188],
-"previousVersion":"http://www.w3.org/TR/2015/WD-navigation-timing-2-20150527/",
+"previousVersion":"http://www.w3.org/TR/2015/WD-navigation-timing-2-20150604/",
 "groupName": "Web Performance Working Group",
 "groupHomepage": "http://www.w3.org/2010/webperf/",
 "groupID": "45211",


### PR DESCRIPTION
See #185. It's happened again.

Last time I update this manually. Let's think a better way to do this.