### PR TITLE
Update outdated devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     "third-party-resources-checker": "^1.0.2"
   },
   "devDependencies": {
-    "chai": "^2.3.0",
-    "chai-as-promised": "^5.0.0",
-    "chai-immutable": "^0.3.0",
+    "chai": "^3.0.0",
+    "chai-as-promised": "^5.1.0",
+    "chai-immutable": "^1.0.1",
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.13",
     "jscs": "^1.13.1",


### PR DESCRIPTION
- `chai-immutable` leaves `0.y.z` versions to go to `1.y.z` versions
- `chai` goes to version 3+
- `chai-as-promised` goes to version `5.1.0` to support chai 3 in its `peerDependencies`