### PR TITLE
Check dependencies against nodesecurity.io DB as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script:
   - cp config.js.example config.js
 after_script:
   - npm run coveralls
+  - npm run nsp
 notifications:
   email: false
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ node_js:
   - "0.10"
 before_script:
   - cp config.js.example config.js
+  - npm run nsp
 after_script:
   - npm run coveralls
-  - npm run nsp
 notifications:
   email: false
   irc:

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "lint": "jshint .",
     "nsp": "nsp package",
     "start": "node app.js",
-    "test": "npm run check-style && npm run lint && mocha",
+    "test": "npm run nsp && npm run check-style && npm run lint && mocha",
     "testserver": "node test/lib/testserver"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -64,13 +64,15 @@
     "jscs": "^1.13.1",
     "jshint": "^2.7.0",
     "mocha": "^2.2.4",
-    "morgan": "^1.5.2"
+    "morgan": "^1.5.2",
+    "nsp": "^1.0"
   },
   "scripts": {
     "check-style": "jscs .",
     "coverage": "istanbul cover _mocha",
     "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
     "lint": "jshint .",
+    "nsp": "nsp package",
     "start": "node app.js",
     "test": "npm run check-style && npm run lint && mocha",
     "testserver": "node test/lib/testserver"


### PR DESCRIPTION
Run [`nsp audit-package`](https://github.com/nodesecurity/nsp#nsp-audit-package) during the CI cycle.

(This build fails only because of the reasons explained in #206.)