### PR TITLE
Remove unstable node version from the Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "0.12"
-  - "0.11"
   - "0.10"
 before_script:
   - cp config.js.example config.js


### PR DESCRIPTION
#207 reminded me of this. I recently discovered that, for Node.js, even versions were stable and odd versions were unstable. So much for semantic versioning!

Currently, Node.js ecosystem is as follows:

- `0.12`: Stable
- `0.11`: Unstable, not maintained anymore
- `0.10`: Maintenance

See https://github.com/joyent/node/blob/master/ChangeLog.

Therefore, `0.11` can safely be removed from the build matrix.