### PR TITLE
Travis: remove explicit "npm run nsp" (ran automatically as part of "npm test")

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "0.10"
 before_script:
   - cp config.js.example config.js
-  - npm run nsp
 after_script:
   - npm run coveralls
 notifications:


### PR DESCRIPTION
@astorije [reminded us of this](https://github.com/w3c/echidna/pull/204#discussion_r34558952).