### PR TITLE
Adapt code to Process 2015

### DIFF
--- a/lib/specberus-wrapper.js
+++ b/lib/specberus-wrapper.js
@@ -47,7 +47,7 @@ SpecberusWrapper.validate = function (url) {
       validation: 'simple-validation',
       noRecTrack: false,
       informativeOnly: false,
-      processDocument: '2014'
+      processDocument: '2015'
     };
 
     if (process.env.NODE_ENV === 'dev') {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node-uuid": "^1.4.3",
     "promise": "^7.0.3",
     "request": "^2.58.0",
-    "specberus": "1.1.6",
+    "specberus": "^1.2.0",
     "third-party-resources-checker": "^1.0.2"
   },
   "devDependencies": {

--- a/test/drafts/frame-timing-2/meta.json
+++ b/test/drafts/frame-timing-2/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 August 2014",
-"processURI": "http://www.w3.org/2014/Process-20140801/",
+"process": "28 April 2015",
+"processURI": "http://www.w3.org/2015/04/Process-20150428/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/frame-timing-2/meta.json
+++ b/test/drafts/frame-timing-2/meta.json
@@ -1,5 +1,5 @@
 {
-"process": "28 April 2015",
+"process": "1 September 2015",
 "processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",

--- a/test/drafts/frame-timing-2/meta.json
+++ b/test/drafts/frame-timing-2/meta.json
@@ -1,6 +1,6 @@
 {
 "process": "28 April 2015",
-"processURI": "http://www.w3.org/2015/04/Process-20150428/",
+"processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/frame-timing/meta.json
+++ b/test/drafts/frame-timing/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 August 2014",
-"processURI": "http://www.w3.org/2014/Process-20140801/",
+"process": "28 April 2015",
+"processURI": "http://www.w3.org/2015/04/Process-20150428/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/frame-timing/meta.json
+++ b/test/drafts/frame-timing/meta.json
@@ -1,5 +1,5 @@
 {
-"process": "28 April 2015",
+"process": "1 September 2015",
 "processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",

--- a/test/drafts/frame-timing/meta.json
+++ b/test/drafts/frame-timing/meta.json
@@ -1,6 +1,6 @@
 {
 "process": "28 April 2015",
-"processURI": "http://www.w3.org/2015/04/Process-20150428/",
+"processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/nav-csserror/meta.json
+++ b/test/drafts/nav-csserror/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 August 2014",
-"processURI": "http://www.w3.org/2014/Process-20140801/",
+"process": "28 April 2015",
+"processURI": "http://www.w3.org/2015/04/Process-20150428/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/nav-csserror/meta.json
+++ b/test/drafts/nav-csserror/meta.json
@@ -1,5 +1,5 @@
 {
-"process": "28 April 2015",
+"process": "1 September 2015",
 "processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",

--- a/test/drafts/nav-csserror/meta.json
+++ b/test/drafts/nav-csserror/meta.json
@@ -1,6 +1,6 @@
 {
 "process": "28 April 2015",
-"processURI": "http://www.w3.org/2015/04/Process-20150428/",
+"processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/nav-csswarning/meta.json
+++ b/test/drafts/nav-csswarning/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 August 2014",
-"processURI": "http://www.w3.org/2014/Process-20140801/",
+"process": "28 April 2015",
+"processURI": "http://www.w3.org/2015/04/Process-20150428/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/nav-csswarning/meta.json
+++ b/test/drafts/nav-csswarning/meta.json
@@ -1,5 +1,5 @@
 {
-"process": "28 April 2015",
+"process": "1 September 2015",
 "processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",

--- a/test/drafts/nav-csswarning/meta.json
+++ b/test/drafts/nav-csswarning/meta.json
@@ -1,6 +1,6 @@
 {
 "process": "28 April 2015",
-"processURI": "http://www.w3.org/2015/04/Process-20150428/",
+"processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/nav-missingfiles/meta.json
+++ b/test/drafts/nav-missingfiles/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 August 2014",
-"processURI": "http://www.w3.org/2014/Process-20140801/",
+"process": "28 April 2015",
+"processURI": "http://www.w3.org/2015/04/Process-20150428/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/nav-missingfiles/meta.json
+++ b/test/drafts/nav-missingfiles/meta.json
@@ -1,5 +1,5 @@
 {
-"process": "28 April 2015",
+"process": "1 September 2015",
 "processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",

--- a/test/drafts/nav-missingfiles/meta.json
+++ b/test/drafts/nav-missingfiles/meta.json
@@ -1,6 +1,6 @@
 {
 "process": "28 April 2015",
-"processURI": "http://www.w3.org/2015/04/Process-20150428/",
+"processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/navigation-timing-2-generated/meta.json
+++ b/test/drafts/navigation-timing-2-generated/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 August 2014",
-"processURI": "http://www.w3.org/2014/Process-20140801/",
+"process": "28 April 2015",
+"processURI": "http://www.w3.org/2015/04/Process-20150428/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/navigation-timing-2-generated/meta.json
+++ b/test/drafts/navigation-timing-2-generated/meta.json
@@ -1,5 +1,5 @@
 {
-"process": "28 April 2015",
+"process": "1 September 2015",
 "processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",

--- a/test/drafts/navigation-timing-2-generated/meta.json
+++ b/test/drafts/navigation-timing-2-generated/meta.json
@@ -1,6 +1,6 @@
 {
 "process": "28 April 2015",
-"processURI": "http://www.w3.org/2015/04/Process-20150428/",
+"processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/navigation-timing-2/meta.json
+++ b/test/drafts/navigation-timing-2/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 August 2014",
-"processURI": "http://www.w3.org/2014/Process-20140801/",
+"process": "1 September 2015",
+"processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "https://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/navigation-timing/meta.json
+++ b/test/drafts/navigation-timing/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 August 2014",
-"processURI": "http://www.w3.org/2014/Process-20140801/",
+"process": "28 April 2015",
+"processURI": "http://www.w3.org/2015/04/Process-20150428/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/navigation-timing/meta.json
+++ b/test/drafts/navigation-timing/meta.json
@@ -1,5 +1,5 @@
 {
-"process": "28 April 2015",
+"process": "1 September 2015",
 "processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",

--- a/test/drafts/navigation-timing/meta.json
+++ b/test/drafts/navigation-timing/meta.json
@@ -1,6 +1,6 @@
 {
 "process": "28 April 2015",
-"processURI": "http://www.w3.org/2015/04/Process-20150428/",
+"processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/resource-timing/meta.json
+++ b/test/drafts/resource-timing/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 August 2014",
-"processURI": "http://www.w3.org/2014/Process-20140801/",
+"process": "28 April 2015",
+"processURI": "http://www.w3.org/2015/04/Process-20150428/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/resource-timing/meta.json
+++ b/test/drafts/resource-timing/meta.json
@@ -1,5 +1,5 @@
 {
-"process": "28 April 2015",
+"process": "1 September 2015",
 "processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",

--- a/test/drafts/resource-timing/meta.json
+++ b/test/drafts/resource-timing/meta.json
@@ -1,6 +1,6 @@
 {
 "process": "28 April 2015",
-"processURI": "http://www.w3.org/2015/04/Process-20150428/",
+"processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/webrtc-stats/meta.json
+++ b/test/drafts/webrtc-stats/meta.json
@@ -1,6 +1,6 @@
 {
 "process": "28 April 2015",
-"processURI": "http://www.w3.org/2015/04/Process-20150428/",
+"processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Identifiers for WebRTC's Statistics API",
 "shortname": "webrtc-stats",

--- a/test/drafts/webrtc-stats/meta.json
+++ b/test/drafts/webrtc-stats/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 August 2014",
-"processURI": "http://www.w3.org/2014/Process-20140801/",
+"process": "28 April 2015",
+"processURI": "http://www.w3.org/2015/04/Process-20150428/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Identifiers for WebRTC's Statistics API",
 "shortname": "webrtc-stats",

--- a/test/drafts/webrtc-stats/meta.json
+++ b/test/drafts/webrtc-stats/meta.json
@@ -1,5 +1,5 @@
 {
-"process": "28 April 2015",
+"process": "1 September 2015",
 "processURI": "http://www.w3.org/2015/Process-20150901/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Identifiers for WebRTC's Statistics API",


### PR DESCRIPTION
As per [proposed process 1 September 2015](http://www.w3.org/2015/Process-20150901/).
See also [the roll-out plan](https://www.w3.org/Team/wiki/Process2015#Echidna_.26_Specberus).
This addresses #213.

This PR is intended as a place for tests and discussion for a while.
:warning: **Do not merge until 1 Sep 2015.**
:warning: **Will only work with Specberus `1.2.0` or greater**; remember to tag Specberus before merging and deploying this change in Echidna.