### PR TITLE
Temporary http location doesn't need a trailing slash

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -1,7 +1,8 @@
 'use strict';
 
 global.DEFAULT_TEMP_LOCATION = '/var/www/';
-global.DEFAULT_HTTP_LOCATION = 'http://spec-server/';
+// DEFAULT_HTTP_LOCATION without trailing slash
+global.DEFAULT_HTTP_LOCATION = 'http://spec-server';
 global.DEFAULT_LOG_LOCATION = '.';
 global.DEFAULT_RESULT_LOCATION = '/var/www/';
 global.DEFAULT_PORT = 3000;


### PR DESCRIPTION
That slash is already added [here](https://github.com/w3c/echidna/blob/master/app.js#L109).