### PR TITLE
Migrate to Node.js 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.10"
+  - "4.1"
 before_script:
   - cp config.js.example config.js
 script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,7 @@ Discuss the publication workflow and related tools [on the mailing list](http://
 
 Start by looking through the [existing bugs](https://github.com/w3c/echidna/issues) to see if this was already discussed earlier. You might even find your solution there.
 
-**NB:** as of today, Echidna and Specberus are developed, tested and deployed using [Node.js](http://nodejs.org/) `v0.12.0`
-and [npm](https://www.npmjs.org/) `2.5.1`.
-When reporting bugs, please make sure you can reproduce them with this recommended setup.
-Also, remember to update npm dependencies often.
+Remember to update [Node.js](https://nodejs.org/en/) and [npm](https://www.npmjs.com/) often, and the npm dependencies of the project too.
 
 If you do not find anything, you can help report bugs by [filing them here](https://github.com/w3c/echidna/issues/new). Please use the following template when doing so:
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Please [see the wiki](https://github.com/w3c/echidna/wiki) for how to use Echidn
 
 ### Installation
 
-To run Echidna, you need to install [Node.js](http://nodejs.org/) first.
-This will install [npm](https://www.npmjs.org/) at the same time, which is required as well.
+To run Echidna, you need to install [Node.js](https://nodejs.org/en/) first.
+This will install [npm](https://www.npmjs.com/) at the same time, which is required as well.
 
 Then run the following commands with your favorite terminal:
 
@@ -50,7 +50,7 @@ You may use the optional defined below:
 (Default `3000`.)
 4. `RESULT_PATH`: local path where Echidna will dump the results of publication requests in JSON format.
 
-Note that they are only supported by npm 2 and above. Alternatively, you can use the configuration file `config.js`.
+Alternatively, you can use the configuration file `config.js`.
 
 Once the server is started, you can throw publication requests at it through a `curl`/`POST` request to its enpoint, <http://localhost:3000/api>, or using the web-based testbed (described below).
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "testserver": "node test/lib/testserver"
   },
   "engines": {
-    "node": ">=0.10.0",
-    "npm": "1.2.x"
+    "node": ">=4.1.2",
+    "npm": ">=3.3.6"
   }
 }


### PR DESCRIPTION
* Node.js &ge; `4.1.2`
* npm &ge; `3.3.6`
* Update also Travis environment
* Update docs accordingly

Fixes #234.

@deniak: please merge this in sync with w3c/specberus#263 and w3c/spec-generator#18, to be able to [update Node.js and npm in production](https://github.com/nodesource/distributions#manual-installation) right after.