### PR TITLE
upgrade nsp

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
     "morgan": "^1.6.1",
-    "nsp": "^1.0.3"
+    "nsp": "^2.0.1"
   },
   "scripts": {
     "check-style": "jscs .",
@@ -74,7 +74,7 @@
     "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
     "jsdoc": "jsdoc -a all -d doc/api/ -e utf8 -r app.js lib/ test/",
     "lint": "jshint .",
-    "nsp": "nsp package",
+    "nsp": "nsp check",
     "start": "node app.js",
     "test": "npm run check-style && npm run lint && mocha",
     "testserver": "node test/lib/testserver"


### PR DESCRIPTION
Major `nsp` upgrade (still reports a vulnerability related to `specberus`/`socket.io` though).
```
┌───────────────┬───────────────────────────────────────────────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                                                          │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ Name          │ ms                                                                                            │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ Installed     │ 0.6.2                                                                                         │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <0.7.0                                                                                        │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ Patched       │ >=0.7.0                                                                                       │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ Path          │ socket.io > socket.io-adapter > debug > ms                                                    │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/46                                                         │
└───────────────┴───────────────────────────────────────────────────────────────────────────────────────────────┘
```