### PR TITLE
Temporary fix for https://nodesecurity.io/advisories/46

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node-uuid": "^1.4.3",
     "promise": "^7.0.3",
     "request": "^2.58.0",
-    "specberus": "https://travis-ci.org/w3c/specberus#master",
+    "specberus": "http://travis-ci.org/w3c/specberus#master",
     "third-party-resources-checker": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node-uuid": "^1.4.3",
     "promise": "^7.0.3",
     "request": "^2.58.0",
-    "specberus": "http://travis-ci.org/w3c/specberus#master",
+    "specberus": "http://travis-ci.org/w3c/specberus",
     "third-party-resources-checker": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node-uuid": "^1.4.3",
     "promise": "^7.0.3",
     "request": "^2.58.0",
-    "specberus": "http://travis-ci.org/w3c/specberus",
+    "specberus": "w3c/specberus",
     "third-party-resources-checker": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node-uuid": "^1.4.3",
     "promise": "^7.0.3",
     "request": "^2.58.0",
-    "specberus": "^1.2.1",
+    "specberus": "https://travis-ci.org/w3c/specberus#master",
     "third-party-resources-checker": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node-uuid": "^1.4.3",
     "promise": "^7.0.3",
     "request": "^2.58.0",
-    "specberus": "w3c/specberus",
+    "specberus": "git://github.com/w3c/specberus.git",
     "third-party-resources-checker": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Merge this *after* w3c/specberus#268, to ensure (temporarily) that Echidna builds pass correctly.

To be undone once [the vulnerability](https://nodesecurity.io/advisories/46) has been fixed in all those other packages.