### PR TITLE
urls in manifest shouldn't be allowed

### DIFF
--- a/lib/document-downloader.js
+++ b/lib/document-downloader.js
@@ -64,6 +64,7 @@ DocumentDownloader.isAllowed = function isAllowed(filename) {
   else if (filename.toLowerCase().indexOf('.php') !== -1) return false;
   else if (filename.indexOf('CVS') !== -1) return false;
   else if (filename.indexOf('../') !== -1) return false;
+  else if (filename.indexOf('://') !== -1) return false;
   else return true;
 };
 


### PR DESCRIPTION
If a manifest lists urls, echidna will create sub-folders:
```
index.html?specStatus=WD;shortName=foobar respec
https://www.w3.org/StyleSheets/TR/W3C-WD
https://www.w3.org/Icons/w3c_home
https://www.w3.org/StyleSheets/TR/logo-WD
```
see https://github.com/w3c/html-aria/pull/17/files

That PR forbids resources having `://` in its name.