### PR TITLE
support for tar upload

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(corsHandler);
 app.use(express.static('assets/'));
 
-// for parsing multipart/form-data
+// For parsing multipart/form-data
 var upload = multer();
 
 // Index Page
@@ -83,6 +83,7 @@ app.post('/api/request', upload.single('tar'), function (req, res) {
   var decision = req.body ? req.body.decision : null;
   var token = req.body ? req.body.token : null;
   var id = Uuid.v4();
+
   if (!(url || tar) || !decision || !token) {
     res.status(500).send(
       'Missing required parameters “url”/"tar", “decision” and/or “token”.'

--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ var meta = require('./package.json');
 var express = require('express');
 var compression = require('compression');
 var bodyParser = require('body-parser');
+var multer = require('multer');
 var path = require('path');
 var Fs = require('fs');
 var Map = require('immutable').Map;
@@ -35,6 +36,9 @@ app.use(compression());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(corsHandler);
 app.use(express.static('assets/'));
+
+// for parsing multipart/form-data
+var upload = multer();
 
 // Index Page
 app.get('/', function (request, response) {
@@ -73,18 +77,21 @@ function dumpJobResult(dest, result) {
   });
 }
 
-app.post('/api/request', function (req, res) {
+app.post('/api/request', upload.single('tar'), function (req, res) {
   var url = req.body ? req.body.url : null;
+  var tar = (!url && req.file) ? req.file : null;
   var decision = req.body ? req.body.decision : null;
   var token = req.body ? req.body.token : null;
   var id = Uuid.v4();
-
-  if (!url || !decision || !token) {
+  if (!(url || tar) || !decision || !token) {
     res.status(500).send(
-      'Missing required parameters “url”, “decision” and/or “token”.'
+      'Missing required parameters “url”/"tar", “decision” and/or “token”.'
     );
   }
   else {
+    var tempLocation = argTempLocation + path.sep + id + path.sep;
+    var httpLocation = argHttpLocation + '/' + id + '/Overview.html';
+
     requests[id] = {
       id: id,
       url: url,
@@ -105,11 +112,9 @@ app.post('/api/request', function (req, res) {
       )
     };
 
-    var tempLocation = argTempLocation + path.sep + id + path.sep;
-    var httpLocation = argHttpLocation + '/' + id + '/Overview.html';
-
     var orchestrator = new Orchestrator(
       url,
+      tar,
       token,
       tempLocation,
       httpLocation,

--- a/lib/document-downloader.js
+++ b/lib/document-downloader.js
@@ -71,7 +71,6 @@ DocumentDownloader.isAllowed = function isAllowed(filename) {
 DocumentDownloader.fetchAndInstall = function (url, dest) {
   var _ = DocumentDownloader; // Class name shortener
   var mkdir = Promise.denodeify(Fs.mkdir);
-
   return new Promise(function (resolve) {
     Fs.exists(dest, function (exists) { resolve(exists); });
   }).then(function (pathExists) {
@@ -80,23 +79,24 @@ DocumentDownloader.fetchAndInstall = function (url, dest) {
     return _.fetch(url).then(function (content) {
       var fileType = require('file-type');
       var type = fileType(content);
-
       if (type && type.mime === 'application/x-tar') {
         return new Promise(function (resolve, reject) {
           var tar = require('tar-stream');
           var extract = tar.extract();
           var hasOverview = false;
-
           extract.on('entry', function (header, stream, callback) {
             stream.on('data', function (data) {
               if (_.isAllowed(header.name)) {
                 if (header.name === 'Overview.html') {
                   hasOverview = true;
                 }
-                _.install(dest + '/' + header.name, data).then(function () {
-                  callback();
-                });
+                var path = require('path').dirname(dest + '/' + header.name);
+                Mkdirp.sync(path);
+                Fs.writeFileSync(dest + '/' + header.name, data);
               }
+            });
+            stream.on('end', function() {
+              callback();
             });
           });
           extract.on('finish', function () {

--- a/lib/document-downloader.js
+++ b/lib/document-downloader.js
@@ -71,6 +71,7 @@ DocumentDownloader.isAllowed = function isAllowed(filename) {
 DocumentDownloader.fetchAndInstall = function (url, dest) {
   var _ = DocumentDownloader; // Class name shortener
   var mkdir = Promise.denodeify(Fs.mkdir);
+
   return new Promise(function (resolve) {
     Fs.exists(dest, function (exists) { resolve(exists); });
   }).then(function (pathExists) {
@@ -79,11 +80,13 @@ DocumentDownloader.fetchAndInstall = function (url, dest) {
     return _.fetch(url).then(function (content) {
       var fileType = require('file-type');
       var type = fileType(content);
+
       if (type && type.mime === 'application/x-tar') {
         return new Promise(function (resolve, reject) {
           var tar = require('tar-stream');
           var extract = tar.extract();
           var hasOverview = false;
+
           extract.on('entry', function (header, stream, callback) {
             stream.on('data', function (data) {
               if (_.isAllowed(header.name)) {
@@ -91,11 +94,12 @@ DocumentDownloader.fetchAndInstall = function (url, dest) {
                   hasOverview = true;
                 }
                 var path = require('path').dirname(dest + '/' + header.name);
+
                 Mkdirp.sync(path);
                 Fs.writeFileSync(dest + '/' + header.name, data);
               }
             });
-            stream.on('end', function() {
+            stream.on('end', function () {
               callback();
             });
           });

--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -163,9 +163,13 @@ Orchestrator.prototype.runStep = function (step) {
 };
 
 // @returns Map[String, Promise[Map[String, *]]]
-Orchestrator.prototype.runDocumentDownloader = function (url, tar, tempLocation, httpLocation) {
+Orchestrator.prototype.runDocumentDownloader = function (url,
+                                                         tar,
+                                                         tempLocation,
+                                                         httpLocation) {
   var finalUrl = url;
   var isTar = (!url && tar);
+
   if (isTar) {
     DocumentDownloader.install(tempLocation + tar.originalname, tar.buffer);
     finalUrl = httpLocation.replace(/Overview.html/, tar.originalname);
@@ -351,7 +355,10 @@ Orchestrator.prototype.next = function (state) {
 
   if (state.hasJobStarted('retrieve-resources')) {
     state = state.set('status', 'started');
-    step = this.runDocumentDownloader(this.url, this.tar, this.tempLocation, this.httpLocation);
+    step = this.runDocumentDownloader(this.url,
+                                      this.tar,
+                                      this.tempLocation,
+                                      this.httpLocation);
   }
   else if (state.hasJobStarted('specberus')) {
     step = this.runSpecberus(this.httpLocation);

--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var exec = require('child_process').exec;
+var Fs = require('fs');
 var Immutable = require('immutable');
 var List = Immutable.List;
 var Map = Immutable.Map;
@@ -47,8 +48,9 @@ function updateTrShortlink(uri) {
  * @exports lib/orchestrator
  */
 
-var Orchestrator = function (url, token, tempLoc, httpLoc, resultLoc) {
+var Orchestrator = function (url, tar, token, tempLoc, httpLoc, resultLoc) {
   this.url = url;
+  this.tar = tar;
   this.token = token;
   this.tempLocation = tempLoc;
   this.httpLocation = httpLoc;
@@ -161,16 +163,24 @@ Orchestrator.prototype.runStep = function (step) {
 };
 
 // @returns Map[String, Promise[Map[String, *]]]
-Orchestrator.prototype.runDocumentDownloader = function (url, tempLocation) {
+Orchestrator.prototype.runDocumentDownloader = function (url, tar, tempLocation, httpLocation) {
+  var finalUrl = url;
+  var isTar = (!url && tar);
+  if (isTar) {
+    DocumentDownloader.install(tempLocation + tar.originalname, tar.buffer);
+    finalUrl = httpLocation.replace(/Overview.html/, tar.originalname);
+  }
   return new Map({
     name: 'retrieve-resources',
-    promise: DocumentDownloader.fetchAndInstall(url, tempLocation)
+    promise: DocumentDownloader.fetchAndInstall(finalUrl, tempLocation)
       .then(function () {
+        if (isTar) Fs.unlinkSync(tempLocation + tar.originalname);
         return new Map({
           status: 'ok',
           history: 'The file has been retrieved.'
         });
       }).catch(function (error) {
+        if (isTar) Fs.unlinkSync(tempLocation + tar.originalname);
         return new Map({
           status: 'error',
           errors: List.of(error.toString()),
@@ -341,7 +351,7 @@ Orchestrator.prototype.next = function (state) {
 
   if (state.hasJobStarted('retrieve-resources')) {
     state = state.set('status', 'started');
-    step = this.runDocumentDownloader(this.url, this.tempLocation);
+    step = this.runDocumentDownloader(this.url, this.tar, this.tempLocation, this.httpLocation);
   }
   else if (state.hasJobStarted('specberus')) {
     step = this.runSpecberus(this.httpLocation);

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "immutable": "3.7",
     "mkdirp": "0.5",
     "moment": "2.10",
+    "multer": "1.1",
     "node-uuid": "1.4",
     "promise": "7.0",
     "request": "2.67",


### PR DESCRIPTION
PR #241 didn't include the tar upload to echidna. This is a [problem for some WGs](https://lists.w3.org/Archives/Public/spec-prod/2015OctDec/0080.html).
That PR should fix that.

To upload the tar via `curl`:
```
curl 'http://<echidnahost>/api/request' -F "tar=@/some/path/spec.tar" -F "decision=<decision>" -F "token=<token>"
```

fix #243 