### PR TITLE
Specberus.extractMetadata now extracts all the metadata

### DIFF
--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -209,14 +209,23 @@ Orchestrator.prototype.runMetadataExtractor = function (httpLocation) {
     name: 'metadata',
     promise: SpecberusWrapper.extractMetadata(httpLocation)
       .then(function (metadata) {
-        if (metadata.profile && metadata.delivererIDs) {
+        if (metadata) {
           return new Map({
             status: 'ok',
             history: 'The metadata have been extracted.',
             metadata: new Map({
               profile: metadata.profile,
+              thisVersion: metadata.thisVersion,
+              latestVersion: metadata.latestVersion,
+              previousVersion: metadata.previousVersion,
+              date: metadata.docDate,
+              title: metadata.title,
               delivererIDs: metadata.delivererIDs,
-              rectrack: metadata.rectrack
+              editors: metadata.editorIDs,
+              rectrack: metadata.rectrack,
+              informative: metadata.informative,
+              editorDraft: metadata.editorsDraft,
+              processRules: metadata.process
             })
           });
         }
@@ -274,8 +283,7 @@ Orchestrator.prototype.runSpecberus = function (httpLocation,
         if (report.errors.isEmpty()) {
           return new Map({
             status: 'ok',
-            history: 'The document passed Specberus.',
-            metadata: report.metadata
+            history: 'The document passed Specberus.'
           });
         }
         else {

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -38,12 +38,13 @@ Publisher.prototype.publish = function (metadata) {
       uri: metadata.get('thisVersion'),
       latestVersionUri: metadata.get('latestVersion'),
       previousVersionUri: metadata.get('previousVersion'),
-      date: new Moment(metadata.get('docDate'), 'YYYY-MM-DD').format('YYYY-MM-DD'),
+      date: new Moment(metadata.get('docDate'), 'YYYY-MM-DD')
+              .format('YYYY-MM-DD'),
       title: metadata.get('title'),
       deliverers: metadata.get('delivererIDs'),
       editors: metadata.get('editorIDs'),
       rectrack: metadata.get('rectrack'),
-      informative: metadata.get('informative')
+      informative: metadata.get('informative'),
       editorDraft: metadata.get('editorsDraft'),
       processRules: metadata.get('process')
     }

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -38,12 +38,12 @@ Publisher.prototype.publish = function (metadata) {
       uri: metadata.get('thisVersion'),
       latestVersionUri: metadata.get('latestVersion'),
       previousVersionUri: metadata.get('previousVersion'),
-      date: new Moment(metadata.get('docDate')).format('YYYY-MM-DD'),
+      date: new Moment(metadata.get('docDate'), 'YYYY-MM-DD').format('YYYY-MM-DD'),
       title: metadata.get('title'),
       deliverers: metadata.get('delivererIDs'),
       editors: metadata.get('editorIDs'),
       rectrack: metadata.get('rectrack'),
-      informative: false, // FIXME Not always true
+      informative: metadata.get('informative')
       editorDraft: metadata.get('editorsDraft'),
       processRules: metadata.get('process')
     }


### PR DESCRIPTION
**Do not merge** this before https://github.com/w3c/specberus/pull/331
Fix #277 