### PR TITLE
check if the memberOf regex matches before returning the group

### DIFF
--- a/lib/user-checker.js
+++ b/lib/user-checker.js
@@ -17,7 +17,9 @@ UserChecker.check = function (user, delivererIDs) {
   return new Promise(function (resolve) {
     var errors = new List();
     var groups = user.memberOf.map(function (group) {
-      return Number(group.match(/^cn=(\d*),ou=groups,dc=w3,dc=org$/i)[1]);
+      var matches = group.match(/^cn=(\d*),ou=groups,dc=w3,dc=org$/i);
+
+      if (matches) return Number(matches[1]);
     });
 
     for (var i = 0; i < delivererIDs.length; i++) {


### PR DESCRIPTION
Some users belong to ldap groups that don't match the regex. Check if there's a match before returning the group.