### PR TITLE
Omnibus PR

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,6 @@
+{
+    "exceptions": [
+      "https://nodesecurity.io/advisories/106",
+      "https://nodesecurity.io/advisories/120"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -48,13 +48,13 @@
     "express": "4.14.0",
     "file-type": "3.8",
     "immutable": "3.8.1",
+    "ldapauth-fork": "2.5",
     "mkdirp": "0.5",
     "moment": "2.14.1",
     "multer": "1.1",
     "node-uuid": "1.4",
     "passport": "0.3",
     "passport-http": "0.3",
-    "ldapauth-fork": "2.5",
     "promise": "7.1",
     "request": "2.73.0",
     "specberus": "2.1.8",
@@ -69,7 +69,7 @@
     "istanbul": "0.4.4",
     "jscs": "3.0.7",
     "jsdoc": "3.4",
-    "jshint": "2.9",
+    "jshint": "2.9.2",
     "mocha": "2.5.3",
     "morgan": "1.7",
     "nsp": "2.6.1"
@@ -82,7 +82,7 @@
     "lint": "jshint .",
     "nsp": "nsp check",
     "start": "node app.js",
-    "test": "npm run check-style && npm run lint && mocha -c -G",
+    "test": "npm run check-style && npm run lint && mocha",
     "testserver": "node test/lib/testserver"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "request": "2.73.0",
     "specberus": "2.1.8",
     "tar-stream": "1.5.2",
-    "third-party-resources-checker": "1.0"
+    "third-party-resources-checker": "1.0.4"
   },
   "devDependencies": {
     "chai": "3.5",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,4 @@
+--colors
+--growl
+--reporter spec
 --timeout 10000

--- a/views/index.html
+++ b/views/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Orchestrator of W3C's new publication system">
     <meta name="keywords" content="w3c,echidna,publication,workflow">
     <meta name="author" content="W3C">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <link rel="stylesheet" media="handheld, all" href="//www.w3.org/2008/site/css/minimum">
     <link rel="stylesheet" media="print" href="//www.w3.org/2008/site/css/print">
     <link rel="icon" type="image/x-icon" href="images/favicon.ico">


### PR DESCRIPTION
* Move Mocha options to its own config file.
* Sort dependencies alphabetically.
* Make sure we use latest `third-party-resources-checker`, which solves one of the npm deprecation warnings mentioned in #256.
* Have a slightly better `viewport` meta tag.
* Add temporary nsp exceptions file to mute advisories 106 &amp; 120.