### PR TITLE
sendmail script: escape ampersand in param $3 too

### DIFF
--- a/sendmail.sh
+++ b/sendmail.sh
@@ -2,7 +2,7 @@
 
 STATUS=$1
 DEST=$2
-URI=$3
+URI=${3/&/\\\&}
 RESULT=${4/&/\\\&}
 
 if [ $# -lt 3 ]; then


### PR DESCRIPTION
Building up on #352.

This should fix **the URI part** (eg, in [`https://lists.w3.org/Archives/Public/public-tr-notifications/2016Sep/0093.html`](https://lists.w3.org/Archives/Public/public-tr-notifications/2016Sep/0093.html) the URI in both the subject and the body is missing `&md-status=WD` at the end; see [the Travis file](https://github.com/w3c/permissions/blob/master/.travis.yml#L13)).