### PR TITLE
chore(package): update jsdoc to version 3.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "coveralls": "2.11.14",
     "istanbul": "0.4.5",
     "jscs": "3.0.7",
-    "jsdoc": "3.4.1",
+    "jsdoc": "3.4.2",
     "jshint": "2.9.3",
     "mocha": "3.1.0",
     "morgan": "1.7",


### PR DESCRIPTION
Not sure why the PR wasn't automatically created.