### PR TITLE
wrong metadata name passed to the job publisher

### DIFF
--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -42,7 +42,7 @@ Publisher.prototype.publish = function (metadata) {
               .format('YYYY-MM-DD'),
       title: metadata.get('title'),
       deliverers: metadata.get('delivererIDs'),
-      editors: metadata.get('editorIDs'),
+      editors: metadata.get('editors'),
       rectrack: metadata.get('rectrack'),
       informative: metadata.get('informative'),
       editorDraft: metadata.get('editorDraft'),


### PR DESCRIPTION
The jobs in the orchestrator are using the *state* metadata and not the metadata from specberus directly so we need to use the property names from the extractor job, ie [*editors* instead of *editorIDs](https://github.com/w3c/echidna/blob/master/lib/orchestrator.js#L246)