### PR TITLE
Fix value of job IDs in success mail notifications

### DIFF
--- a/app.js
+++ b/app.js
@@ -157,10 +157,10 @@ var processRequest = function (req, res, isTar) {
       }
       else {
         cmd += ' ' + state.get('metadata').get('thisVersion') +
-          ' \'Echidna: ' + meta.version +
+          ' \'Echidna:   ' + meta.version +
           '\nSpecberus: ' + SpecberusWrapper.version +
-          '\nid: ' + SpecberusWrapper.version +
-          '\nDecision: ' + decision + '\'';
+          '\nJob ID:    ' + id +
+          '\nDecision:  ' + decision + '\'';
       }
 
       console.log('[' + state.get('status').toUpperCase() + '] ' + url);


### PR DESCRIPTION
Also, indent columns to make them more readable.

This:

```
Echidna: 1.11.6
Specberus: 3.2.0
id: 3.2.0
Decision: https://foo.bar/baz.html
```

becomes:

```
Echidna:   1.11.6
Specberus: 3.2.0
Job ID:    92898672-4f4b-8dda-b9d8-75229cfa3aa5
Decision:  https://foo.bar/baz.html
```