### PR TITLE
Various minor changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ notifications:
     channels:
       - "irc.w3.org#pub"
     skip_join: true
+    template:
+      - "%{branch} by %{author} (%{build_url}): %{message}"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "mkdirp": "0.5",
     "moment": "2.17.1",
     "multer": "1.3.0",
-    "node-uuid": "1.4",
+    "node-uuid": "1.4.7",
     "passport": "0.3",
     "passport-http": "0.3",
     "promise": "7.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "body-parser": "1.17.1",
     "compression": "1.6",
-    "express": "4.14.1",
+    "express": "4.15.2",
     "file-type": "4.1.0",
     "immutable": "3.8.1",
     "ldapauth-fork": "3.0.0",

--- a/test/lib/testserver.js
+++ b/test/lib/testserver.js
@@ -103,7 +103,6 @@ TestServer.start = function () {
   if (server.address() === null) {
     throw new Error('Cannot find a free port for the test server ' + port);
   }
-  // FIXME Do not override a pseudo-constant!
   global.SPEC_GENERATOR = this.location() + '/generate';
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -391,15 +391,6 @@ describe('SpecberusWrapper', function () {
         .that.is.an.instanceOf(List);
     });
 
-    /* @todo: rethink this test to avoid manual changes every time the spec is updated
-       https://github.com/w3c/echidna/commits/master/test/drafts/navigation-timing-2/meta.json
-
-    it('should return an error property that is an empty list', function () {
-      return expect(content).that.eventually.has.property('errors')
-        .that.is.empty;
-    });
-    */
-
     it('should promise an object with a metadata property', function () {
       return expect(content).to.eventually.have.property('metadata');
     });


### PR DESCRIPTION
* Remove deprecated tests that were commented out and other comment.
* Travis notifications on IRC: one line; less noise.
* Update `node-uuid` ([David thinks we're using an insecure version](https://david-dm.org/w3c/echidna)) and `express`.