### PR TITLE
Fix path to Echidna profiles in Specberus

### DIFF
--- a/lib/specberus-wrapper.js
+++ b/lib/specberus-wrapper.js
@@ -25,10 +25,10 @@ SpecberusWrapper.validate = function (url, profile, isRecTrack) {
     var specberusProfile;
 
     if (profile === 'WD') {
-      specberusProfile = require('specberus/lib/profiles/WD-Echidna');
+      specberusProfile = require('specberus/lib/profiles/TR/WD-Echidna');
     }
     else if (profile === 'WG-NOTE') {
-      specberusProfile = require('specberus/lib/profiles/WG-NOTE-Echidna');
+      specberusProfile = require('specberus/lib/profiles/TR/WG-NOTE-Echidna');
     }
     else {
       return reject(new Error('Only WD and Notes are allowed!'));


### PR DESCRIPTION
(Does not pass tests until Echidna uses a version of Specberus that includes w3c/specberus#601.)