### PR TITLE
Implement --dry-run feature

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -29,7 +29,7 @@
   "disallowSpacesInsideParentheses": true,
   "disallowTrailingComma": true,
   "disallowTrailingWhitespace": true,
-  "maximumLineLength": { "value": 80, "allowComments": true },
+  "maximumLineLength": 160,
   "requireBlocksOnNewline": 1,
   "requireCamelCaseOrUpperCaseIdentifiers": true,
   "requireCapitalizedComments": true,

--- a/app.js
+++ b/app.js
@@ -85,7 +85,7 @@ var processRequest = function (req, res, isTar) {
   var token = (!isTar && req.body) ? req.body.token : null;
   var tar = (isTar) ? req.file : null;
   var user = req.user ? req.user : null;
-  var dryRun = Boolean(req.body && req.body['dry-run'] && /^(true|t|yes|y|1|on)$/i.test(req.body['dry-run']));
+  var dryRun = Boolean(req.body && req.body['dry-run'] && /^true$/i.test(req.body['dry-run']));
 
   if (!((url && token) || tar) || !decision) {
     res.status(500).send(


### PR DESCRIPTION
Closes #420.

The API understands a new optional parameter `dry-run`, and [interprets `true` if its value equals `'true'` (case-insensitive)](https://github.com/w3c/echidna/blob/tripu/dry-run/app.js#L88). Examples:

```bash
$ curl […] -d 'dry-run=true'
$ curl […] -d 'dry-run=TRUE'
$ curl […] -d 'dry-run=yes'    # false; equivalent to not setting the param at all
```

If `dry-run` is set to true, the document is not published, and no e-mail notification is sent (the only way to check results is then via the `status` method of the API).

If/when this is merged and deployed, I'll update [the wiki](https://github.com/w3c/echidna/wiki/How-to-use-Echidna) and I'll send a notice to the [spec-prod ML](https://lists.w3.org/Archives/Public/spec-prod/).