### PR TITLE
fix(package): update tar-stream to version 1.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "promise": "7.1",
     "request": "2.81.0",
     "specberus": "3.2.5",
-    "tar-stream": "1.5.2",
+    "tar-stream": "1.5.4",
     "third-party-resources-checker": "1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Covered by [automatic tests](https://coveralls.io/builds/11517160/source?filename=lib%2Fdocument-downloader.js#L89).