### PR TITLE
Fix nsp errors

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,6 @@
+{
+  "exceptions": [
+    "https://nodesecurity.io/advisories/534",
+    "https://nodesecurity.io/advisories/535"
+  ]
+}

--- a/.nsprc
+++ b/.nsprc
@@ -1,5 +1,6 @@
 {
   "exceptions": [
+    "https://nodesecurity.io/advisories/479",
     "https://nodesecurity.io/advisories/534",
     "https://nodesecurity.io/advisories/535"
   ]

--- a/lib/document-downloader.js
+++ b/lib/document-downloader.js
@@ -27,7 +27,7 @@ DocumentDownloader.fetch = function (url) {
       else if (response.statusCode !== 200) {
         reject(new Error(
           'Fetching ' + url +
-          ' triggered and HTTP error: code ' + response.statusCode
+          ' triggered an HTTP error: code ' + response.statusCode
         ));
       }
       else resolve(body);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "body-parser": "1.18.2",
     "compression": "1.7.1",
-    "express": "4.15.3",
+    "express": "5.0.0-alpha.6",
     "file-type": "6.2.0",
     "immutable": "3.8.1",
     "ldapauth-fork": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "passport-http": "0.3",
     "promise": "8.0.1",
     "request": "2.83.0",
-    "specberus": "3.4.1",
+    "specberus": "3.4.2",
     "tar-stream": "1.5.4",
     "third-party-resources-checker": "1.0.5"
   },

--- a/test/drafts/nav-csserror/meta.json
+++ b/test/drafts/nav-csserror/meta.json
@@ -6,7 +6,7 @@
 "shortname": "navigation-timing-2",
 "status":    "WD",
 "editorIDs": [44357,69474,45188],
-"previousVersion":"https://www.w3.org/TR/2015/WD-navigation-timing-2-20150120/",
+"previousVersion":"https://www.w3.org/TR/2017/WD-navigation-timing-2-20170925/",
 "groupName": "Web Performance Working Group",
 "groupHomepage": "http://www.w3.org/webperf/",
 "groupID": 45211,

--- a/test/drafts/nav-csswarning/meta.json
+++ b/test/drafts/nav-csswarning/meta.json
@@ -6,7 +6,7 @@
 "shortname": "navigation-timing-2",
 "status":    "WD",
 "editorIDs": [44357,69474,45188],
-"previousVersion":"https://www.w3.org/TR/2015/WD-navigation-timing-2-20150120/",
+"previousVersion":"https://www.w3.org/TR/2017/WD-navigation-timing-2-20170925/",
 "groupName": "Web Performance Working Group",
 "groupHomepage": "http://www.w3.org/webperf/",
 "groupID": 45211,


### PR DESCRIPTION
For Express, I rejected greenkeeper's automatic upgrade to [that pre-release](https://github.com/expressjs/express/releases/tag/5.0.0-alpha.6) earlier today, as I usually do, without realising it's the best way to prevent one of the vulnerabilities. Using that now.

The rest of vulns originate in Specberus. This PR depends on Specberus `3.4.1`, which does not exist yet.

Please merge w3c/specberus#684 and tag and publish that new version of Specberus first&nbsp;&mdash;&nbsp;then come here and restart the Travis build, and check that this PR passes.

**Update:** depends on w3c/specberus#690 and future Specberus `3.4.2`