### PR TITLE
Fix the build with a couple of updates

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,6 +1,5 @@
 {
   "exceptions": [
-    "https://nodesecurity.io/advisories/479",
     "https://nodesecurity.io/advisories/534",
     "https://nodesecurity.io/advisories/535"
   ]

--- a/test/drafts/nav-csserror/index.html
+++ b/test/drafts/nav-csserror/index.html
@@ -84,8 +84,8 @@ or obsoleted by other documents at any time. It is inappropriate to
 cite this document as other than work in progress. </p>
 
 <p>This document was produced by a group operating under
-   the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5
-   February 2004 W3C Patent Policy</a>. W3C maintains
+   the <a href="https://www.w3.org/Consortium/Patent-Policy/">
+   W3C Patent Policy</a>. W3C maintains
    a <a href="https://www.w3.org/2004/01/pp-impl/{{groupID}}/status"
    rel="disclosure">public list of any patent disclosures</a> made in
    connection with the deliverables of the group; that page also

--- a/test/drafts/nav-csswarning/index.html
+++ b/test/drafts/nav-csswarning/index.html
@@ -84,8 +84,8 @@ or obsoleted by other documents at any time. It is inappropriate to
 cite this document as other than work in progress. </p>
 
 <p>This document was produced by a group operating under
-   the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5
-   February 2004 W3C Patent Policy</a>. W3C maintains
+   the <a href="https://www.w3.org/Consortium/Patent-Policy/">
+   W3C Patent Policy</a>. W3C maintains
    a <a href="https://www.w3.org/2004/01/pp-impl/{{groupID}}/status"
    rel="disclosure">public list of any patent disclosures</a> made in
    connection with the deliverables of the group; that page also


### PR DESCRIPTION
* Fix two test drafts for Specberus + CSS testing ([this transition](https://github.com/w3c/specberus/pull/697/commits/beebb00274756bcc7d9e1dc1c531ab9fcd2b2a96) expired on 1 Dec)
* Stop ignoring [nsp advisory no. 479](https://nodesecurity.io/advisories/479)