### PR TITLE
Fix tests after switch to process 2018

### DIFF
--- a/test/drafts/nav-csserror/meta.json
+++ b/test/drafts/nav-csserror/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 March 2017",
-"processURI": "https://www.w3.org/2017/Process-20170301/",
+"process": "1 February 2018",
+"processURI": "https://www.w3.org/2018/Process-20180201/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",

--- a/test/drafts/nav-csswarning/meta.json
+++ b/test/drafts/nav-csswarning/meta.json
@@ -1,6 +1,6 @@
 {
-"process": "1 March 2017",
-"processURI": "https://www.w3.org/2017/Process-20170301/",
+"process": "1 February 2018",
+"processURI": "https://www.w3.org/2018/Process-20180201/",
 "editorsDraft": "http://w3c.github.io/navigation-timing/",
 "title":     "Navigation Timing 2",
 "shortname": "navigation-timing-2",


### PR DESCRIPTION
Two tests are failing because we no longer accept documents on process 2017. That PR switches these test documents to process 2018.