### PR TITLE
prettify JSON express response

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,6 +40,7 @@ app.use(compression());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(corsHandler);
 app.use(express.static('assets/'));
+app.set('json spaces', 2);
 
 // Index Page
 app.get('/', function (request, response) {


### PR DESCRIPTION
@tabatkins mentioned the JSON returned by `/api/status` wasn't prettified occasionally.
This actually happens when the request is being processed and the final result hasn't been stored onto the file system. That PR should fix the issue for all express JSON responses.