### PR TITLE
Amend dependencies between Chai packages, and increase timeout for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "third-party-resources-checker": "1.0.6"
   },
   "devDependencies": {
-    "chai": "4.1.2",
+    "chai": "3.5.0",
     "chai-as-promised": "7.1.1",
     "chai-immutable": "1.6.0",
     "coveralls": "3.0.1",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --colors
 --growl
 --reporter spec
---timeout 10000
+--timeout 11000


### PR DESCRIPTION
When I build the current `master` locally, I get this warning:

    npm WARN chai-immutable@1.6.0 requires a peer of chai@>= 2.0.0 < 4 but none is installed.

It's displayed in Travis builds [for Node 8](https://api.travis-ci.org/v3/job/389093009/log.txt) and [for Node 10](https://api.travis-ci.org/v3/job/389093010/log.txt) too.

So, these versions are incompatible.

For some reason, Travis builds succeed anyway. But my local builds fail with this error:

    124 passing (10s)
    1 failing

    1) DocumentDownloader
         fetch(url)
           should reject if the server is not reachable:
       Error: Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (echidna/test/test.js)

Reverting to a compatible version of `chai` and giving tests an extra second before timing out solve the issue for me. Merge?

(@astorije is upgrading `chai-immutable` soon anyway, but while debugging on his branch, I noticed this is currently broken in `origin/master`, and I think it's best to fix it. Also, we don't know how long it'll take for `chai-immutable` `2.x` to leave the stage of prerelease and become stable.)