### PR TITLE
Package node-uuid is deprecated; use uuid instead

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ var multer = require('multer');
 var path = require('path');
 var Fs = require('fs');
 var Map = require('immutable').Map;
-var Uuid = require('node-uuid');
+var Uuid = require('uuid');
 
 var Job = require('./lib/job');
 var Orchestrator = require('./lib/orchestrator');

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "mkdirp": "0.5",
     "moment": "2.22.2",
     "multer": "1.4.1",
-    "node-uuid": "1.4.8",
     "nodemailer": "4.6.8",
     "octokat": "0.10.0",
     "passport": "0.4.0",
@@ -61,7 +60,8 @@
     "request": "2.88.0",
     "specberus": "3.9.2",
     "tar-stream": "1.6.2",
-    "third-party-resources-checker": "1.0.6"
+    "third-party-resources-checker": "1.0.6",
+    "uuid": "3.3.2"
   },
   "devDependencies": {
     "chai": "4.1.2",


### PR DESCRIPTION
This was causing a warning from npm.

The build is still failing due to [a new security advisory](https://www.npmjs.com/advisories/736) &mdash; but that one's coming from Specberus, so let's fix it there.

**Update:** Specberus is already cured, it's just a matter of us tagging a new release and publishing it on npm.