### PR TITLE
Use new "W3C_API_KEY" for Specberus in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 before_script:
   - cp config.js.example config.js
 script:
-  - API_KEY=${API_KEY:-foo} npm run build
+  - W3C_API_KEY=${W3C_API_KEY:-foo} npm run build
 after_script:
   - npm run coveralls
 notifications:


### PR DESCRIPTION
&hellip;whenever Echidna gets the next release of Specberus

cf w3c/specberus#786