### PR TITLE
add optional parameter to annotate a request

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,6 +120,7 @@ var processRequest = function (req, res, isTar) {
 
     requests[id] = {};
     requests[id]['id'] = id;
+    if (req.body && req.body.annotation) requests[id]['annotation'] = req.body.annotation;
     if (isTar) requests[id]['tar'] = tar.originalname;
     else requests[id]['url'] = url;
     requests[id]['version'] = meta.version;


### PR DESCRIPTION
Annotate a request can be helpful to identify a specification if echidna hasn't been able to extract the metadata.
Fix #831