### PR TITLE
Fix decontruct

### DIFF
--- a/lib/json-http-service.js
+++ b/lib/json-http-service.js
@@ -50,7 +50,7 @@ JsonHttpService.prototype = {
         },
         (error, response, bodyResult) => {
           if (error) reject(error);
-          else resolve({ response, bodyResult });
+          else resolve({ response, body: bodyResult });
         },
       );
     });

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -7,7 +7,7 @@
 
 const fs = require('fs');
 const nodemailer = require('nodemailer');
-const meta = require('../package');
+const meta = require('../package.json');
 const Orchestrator = require('./orchestrator');
 const SpecberusWrapper = require('./specberus-wrapper');
 


### PR DESCRIPTION
Recently, Echidna started to report an error after a request in the 'publish' job fail, e.g. https://labs.w3.org/echidna/api/status?id=54938aec-857a-424f-8427-40592dee5155

The bug is due to a recent code style refactoring: https://github.com/w3c/echidna/commit/106ce6d97b38828e99c7a4076cc7bd3b95c7e256#diff-68e1d1c7217131e9452081b60e63a80f81a96d44d2d1ded424ffd72a08b58df4R53

The publisher tries to deconstruct the result (https://github.com/w3c/echidna/blob/main/lib/publisher.js#L67) but since the name of the variable changed, it fails.

The PR fixes that issue and a small lint error.