### PR TITLE
Fix test

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "passport-http": "0.3",
     "promise": "8.1.0",
     "request": "2.88.2",
-    "specberus": "5.7.5",
+    "specberus": "5.7.6",
     "tar-stream": "2.2.0",
     "uuid": "8.3.2"
   },

--- a/test/drafts/nav-csserror/index.html
+++ b/test/drafts/nav-csserror/index.html
@@ -38,7 +38,20 @@
     <dd><a href="https://lists.w3.org/Archives/Public/{{list}}/">archive</a></dd>
 </dl>
 
-<p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © {{YYYY}} <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+<p class="copyright">
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2021
+    <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+    (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+    <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+    <a href="https://www.keio.ac.jp/">Keio</a>,
+    <a href="https://ev.buaa.edu.cn/">Beihang</a>).
+    <abbr title="World Wide Web Consortium">W3C</abbr>
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+    <!-- shortlink for copyright-software, pass check  -->
+    <a href="https://www.w3.org/Consortium/Legal/copyright-software">permissive document license</a>
+    rules apply.
+  </p>
 
    <hr class='top'>
 </div>

--- a/test/drafts/nav-csserror/meta.json
+++ b/test/drafts/nav-csserror/meta.json
@@ -12,5 +12,5 @@
 "groupID": 45211,
 "list": "public-web-perf",
 "rectrack": true,
-"patentPolicy": "https://www.w3.org/Consortium/Patent-Policy-20170801/"
+"patentPolicy": "https://www.w3.org/Consortium/Patent-Policy-20200915/"
 }

--- a/test/drafts/nav-csswarning/index.html
+++ b/test/drafts/nav-csswarning/index.html
@@ -38,7 +38,20 @@
       <dd><a href="https://lists.w3.org/Archives/Public/{{list}}/">archive</a></dd>
 </dl>
 
-<p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © {{YYYY}} <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+<p class="copyright">
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1995-2021
+    <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+    (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+    <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+    <a href="https://www.keio.ac.jp/">Keio</a>,
+    <a href="https://ev.buaa.edu.cn/">Beihang</a>).
+    <abbr title="World Wide Web Consortium">W3C</abbr>
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+    <!-- shortlink for copyright-software, pass check  -->
+    <a href="https://www.w3.org/Consortium/Legal/copyright-software">permissive document license</a>
+    rules apply.
+  </p>
 
    <hr class='top'>
 </div>

--- a/test/drafts/nav-csswarning/meta.json
+++ b/test/drafts/nav-csswarning/meta.json
@@ -12,5 +12,5 @@
 "groupID": 45211,
 "list": "public-web-perf",
 "rectrack": true,
-"patentPolicy": "https://www.w3.org/Consortium/Patent-Policy-20170801/"
+"patentPolicy": "https://www.w3.org/Consortium/Patent-Policy-20200915/"
 }

--- a/test/drafts/webrtc-crd/meta.json
+++ b/test/drafts/webrtc-crd/meta.json
@@ -12,5 +12,5 @@
 "groupID": 47318,
 "list": "public-webrtc",
 "rectrack": true,
-"patentPolicy": "https://www.w3.org/Consortium/Patent-Policy-20170801/"
+"patentPolicy": "https://www.w3.org/Consortium/Patent-Policy-20200915/"
 }

--- a/test/drafts/webrtc-stats/meta.json
+++ b/test/drafts/webrtc-stats/meta.json
@@ -12,5 +12,5 @@
 "groupID": 47318,
 "list": "public-web-perf",
 "rectrack": true,
-"patentPolicy": "https://www.w3.org/Consortium/Patent-Policy-20170801/"
+"patentPolicy": "https://www.w3.org/Consortium/Patent-Policy-20200915/"
 }

--- a/test/drafts/webrtc/meta.json
+++ b/test/drafts/webrtc/meta.json
@@ -12,5 +12,5 @@
 "groupID": 47318,
 "list": "public-webrtc",
 "rectrack": true,
-"patentPolicy": "https://www.w3.org/Consortium/Patent-Policy-20170801/"
+"patentPolicy": "https://www.w3.org/Consortium/Patent-Policy-20200915/"
 }


### PR DESCRIPTION
Fixing new errors in test caused by the upgrade of Specberus, mainly are 'copyright' and 'patentPolicy'.