### PR TITLE
Revert "Bump passport from 0.4.1 to 0.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node-dig-dns": "0.3.1",
     "nodemailer": "6.7.0",
     "octokat": "0.10.0",
-    "passport": "0.5.0",
+    "passport": "0.4.1",
     "passport-http": "0.3",
     "promise": "8.1.0",
     "request": "2.88.2",


### PR DESCRIPTION
Reverts w3c/echidna#951

This contains a breaking change with passport-http.