### PR TITLE
GH actions IPs can be in a different range from what /meta returns

### DIFF
--- a/lib/ip-checker.js
+++ b/lib/ip-checker.js
@@ -35,8 +35,12 @@ IPChecker.check = ip =>
       .then(values => {
         let allowedIPs = [];
         values.forEach(v => {
-          if (v.data && v.data.actions) {
-            allowedIPs = allowedIPs.concat(v.data.actions); // GH Actions
+          if (v.data) {
+            allowedIPs = allowedIPs.concat([
+              ...v.data.hooks,
+              ...v.data.web,
+              ...v.data.actions,
+            ]); // GH Actions
           } else if (v.values) {
             allowedIPs = allowedIPs.concat(
               ...v.values.map(a => a.properties.addressPrefixes),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "echidna",
-  "version": "3.1.13",
+  "version": "3.1.14",
   "description": "Echidna — W3C's orchestrator for the new publication workflow",
   "author": "W3C",
   "keywords": [


### PR DESCRIPTION
It seems some GH actions are now running from servers that aren't listed in the 'actions' range.
That PR includes other ranges when checking the IP

Fix #1049 