### PR TITLE
Add server header when no auth

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -59,6 +59,7 @@
         "tripu",
         "TRpath",
         "trstaging",
-        "uuidv"
+        "uuidv",
+        "W3CACL"
     ]
 }

--- a/app.js
+++ b/app.js
@@ -130,8 +130,11 @@ const processRequest = (req, res, isTar) => {
         'Missing parameters. The valid combination of parameters are "url + token + decision",' +
           ' "tar + token + decision" or "tar + W3C credentials + decision".',
       );
-  } else if (tar && !user && (url || tar) && !token) {
+  } else if ((tar && !user) || ((url || tar) && !token)) {
     // If the submitting the tar without W3C credentials, or submitting the tar or URL without token
+    if (!token || !user) {
+      res.setHeader('WWW-Authenticate', 'Basic realm="echidna"');
+    }
     res
       .status(401) // Unauthorized
       .send(

--- a/app.js
+++ b/app.js
@@ -130,12 +130,10 @@ const processRequest = (req, res, isTar) => {
         'Missing parameters. The valid combination of parameters are "url + token + decision",' +
           ' "tar + token + decision" or "tar + W3C credentials + decision".',
       );
-  } else if ((tar && !user) || ((url || tar) && !token)) {
-    // If the submitting the tar without W3C credentials, or submitting the tar or URL without token
-    if (!token || !user) {
-      res.setHeader('WWW-Authenticate', 'Basic realm="echidna"');
-    }
+  } else if (tar && !user && (url || tar) && !token) {
+    // If submitting the tar without W3C credentials, and submitting the tar or URL without token
     res
+      .setHeader('WWW-Authenticate', 'Basic realm="W3CACL"')
       .status(401) // Unauthorized
       .send(
         'Unauthorized request, missing "token" or "W3C credentials" in the parameters. The valid combination of parameters are "url + token + decision", "tar + token + decision" or "tar + W3C credentials + decision".',


### PR DESCRIPTION
resolves https://github.com/w3c/echidna/issues/1039, also update https://github.com/w3c/echidna/wiki/How-to-use-Echidna#tar-file

After this change, when using `curl --anyauth ...`, the server receives request twice. It gives a 401 with header `WWW-Authenticate: Basic realm="W3CACL"` when no user-password is sent, and '202 Accepted' when having the right credentials.