### PR TITLE
use special header to bypass W3C SSO

### DIFF
--- a/lib/json-http-service.js
+++ b/lib/json-http-service.js
@@ -15,7 +15,7 @@ const Request = require('request');
  * @param {string} pass - The password used for authentication
  * @param {Object} headers - The headers to send along with the POST request
  */
-function JsonHttpService(url, user, pass, headers = {}) {
+function JsonHttpService(url, user, pass, headers) {
   if (typeof this !== 'object') {
     throw new TypeError('JsonHttpService must be constructed via new');
   }
@@ -23,7 +23,8 @@ function JsonHttpService(url, user, pass, headers = {}) {
   if (typeof url !== 'string') throw new TypeError('url must be a string');
   if (typeof user !== 'string') throw new TypeError('user must be a string');
   if (typeof pass !== 'string') throw new TypeError('pass must be a string');
-  if (typeof pass !== 'object') throw new TypeError('pass must be an object');
+  if (typeof headers !== 'object')
+    throw new TypeError('pass must be an object');
 
   this.url = url;
   this.user = user;

--- a/lib/json-http-service.js
+++ b/lib/json-http-service.js
@@ -13,8 +13,9 @@ const Request = require('request');
  * @param {string} url - The URL of the service to POST to
  * @param {string} user - The user used for authentication
  * @param {string} pass - The password used for authentication
+ * @param {Object} headers - The headers to send along with the POST request
  */
-function JsonHttpService(url, user, pass) {
+function JsonHttpService(url, user, pass, headers = {}) {
   if (typeof this !== 'object') {
     throw new TypeError('JsonHttpService must be constructed via new');
   }
@@ -22,10 +23,12 @@ function JsonHttpService(url, user, pass) {
   if (typeof url !== 'string') throw new TypeError('url must be a string');
   if (typeof user !== 'string') throw new TypeError('user must be a string');
   if (typeof pass !== 'string') throw new TypeError('pass must be a string');
+  if (typeof pass !== 'object') throw new TypeError('pass must be an object');
 
   this.url = url;
   this.user = user;
   this.pass = pass;
+  this.headers = headers;
 
   Object.freeze(this);
 }
@@ -46,6 +49,7 @@ JsonHttpService.prototype = {
           url: self.url,
           json: true,
           auth: { user: self.user, pass: self.pass },
+          headers: self.headers,
           body,
         },
         (error, response, bodyResult) => {

--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -532,6 +532,7 @@ Orchestrator.prototype.runPublisher = metadata => {
     global.W3C_PUBSYSTEM_URL,
     global.USERNAME,
     global.PASSWORD,
+    { 'X-W3C-Sso': 'bypass' },
   );
 
   return new Map({

--- a/lib/token-checker.js
+++ b/lib/token-checker.js
@@ -23,6 +23,7 @@ TokenChecker.check = (url, token) =>
   new Promise((resolve, reject) => {
     const options = {
       uri: global.TOKEN_ENDPOINT,
+      headers: { 'X-W3C-Sso': 'bypass' },
       qs: { spec: url, token },
       // USERNAME & PASSWORD is a credential for https://www.w3.org/Web/publications/authorize?
       auth: { user: global.USERNAME, pass: global.PASSWORD },

--- a/test/test-json-http-service.js
+++ b/test/test-json-http-service.js
@@ -13,7 +13,7 @@ const JsonHttpService = require('../lib/json-http-service');
 describe('JsonHttpService', () => {
   describe('object', () => {
     it('should be immutable (aka frozen)', () => {
-      expect(new JsonHttpService('', '', '')).to.be.frozen;
+      expect(new JsonHttpService('', '', '', {})).to.be.frozen;
     });
 
     it('should always be called with new', () => {
@@ -25,13 +25,16 @@ describe('JsonHttpService', () => {
     it('should be given strings as arguments', () => {
       [
         function () {
-          new JsonHttpService(42, '', '');
+          new JsonHttpService(42, '', '', {});
         },
         function () {
-          new JsonHttpService('', 42, '');
+          new JsonHttpService('', 42, '', {});
         },
         function () {
-          new JsonHttpService('', '', 42);
+          new JsonHttpService('', '', 42, {});
+        },
+        function () {
+          new JsonHttpService('', '', '', '');
         },
       ].forEach(f => {
         expect(f).to.throw(TypeError);


### PR DESCRIPTION
W3C will soon change its authentication method. This PR adds a special header to bypass SSO so we can still rely on basic auth to access the endpoints we need.