### PR TITLE
Remove obsolete specberus params

### DIFF
--- a/lib/specberus-wrapper.js
+++ b/lib/specberus-wrapper.js
@@ -84,17 +84,10 @@ SpecberusWrapper.validate = (url, stateMetadata) =>
         );
       }
 
-      const pp =
-        patentPolicy === 'https://www.w3.org/Consortium/Patent-Policy-20170801/'
-          ? 'pp2004'
-          : 'pp2020';
       const options = {
         url,
         profile: specberusProfile,
         events: sink,
-        validation: 'simple-validation',
-        informativeOnly: false,
-        patentPolicy: pp,
       };
 
       if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
These parameters currently have no effect, and future versions of Pubrules will treat `informativeOnly` and `patentPolicy` as unknown parameters and reject requests containing them.

See also https://github.com/w3c/specberus/pull/2081