### PR TITLE
Update specberus-wrapper and tests for Specberus v13

### DIFF
--- a/lib/specberus-wrapper.js
+++ b/lib/specberus-wrapper.js
@@ -1,16 +1,10 @@
- 
 /**
  * @file A [Specberus](https://github.com/w3c/specberus) wrapper. Validate the compliance of Technical Reports with [publication rules](https://www.w3.org/pubrules/doc).
  */
 
 'use strict';
 
-import Promise from 'promise';
-import pkg from 'immutable';
-import util from 'util';
-import { EventEmitter } from 'events';
-
-const { List, Map } = pkg;
+import { List } from 'immutable';
 
 /**
  * @exports lib/specberus-wrapper
@@ -19,118 +13,74 @@ const { List, Map } = pkg;
 const SpecberusWrapper = {};
 // import specberus and create it once.
 SpecberusWrapper.getSpecberus = async () => {
-  const Specberus = await import('specberus/lib/validator.js');
-  return new Specberus.Specberus();
+  const { Specberus } = await import('specberus');
+  return new Specberus();
 };
 
-SpecberusWrapper.validate = (url, stateMetadata) =>
-  new Promise((resolve, reject) => {
-    function Sink() {}
+SpecberusWrapper.validate = async (url, stateMetadata) => {
+  let errors = new List();
+  let specberusProfile;
 
-    util.inherits(Sink, EventEmitter);
+  const profile = stateMetadata.get('profile');
+  const patentPolicy = stateMetadata.get('patentPolicy');
+  if (
+    ['WD', 'CR', 'CRD'].includes(profile) ||
+    (profile === 'REC' && stateMetadata.get('recCandidateAmendments'))
+  ) {
+    specberusProfile = await import(
+      `specberus/lib/profiles/TR/Recommendation/${profile}-Echidna.js`
+    );
+  } else if (['NOTE', 'DNOTE'].includes(profile)) {
+    specberusProfile = await import(
+      `specberus/lib/profiles/TR/Note/${profile}-Echidna.js`
+    );
+  } else if (profile === 'DRY') {
+    specberusProfile = await import(
+      `specberus/lib/profiles/TR/Registry/${profile}-Echidna.js`
+    );
+  } else {
+    throw new Error(
+      'Only WD, CR, CRD, REC with candidate amendments, DNOTE, NOTE and DRY are allowed!',
+    );
+  }
 
-    const sink = new Sink();
-    let errors = new List();
-    let metadata = new Map();
-    let specberusProfile;
+  const options = {
+    url,
+    profile: specberusProfile,
+  };
 
-    sink.on('end-all', () => {
-      resolve({ errors, metadata });
-    });
+  if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'test') {
+    const host = `http://localhost:${(process.env.PORT || 3000) + 1}`;
+    options.htmlValidator = `${host}/nu`;
+  }
 
-    sink.on('metadata', (key, value) => {
-      metadata = metadata.set(key, value);
-    });
-
-    sink.on('err', (type, errData) => {
-      const data = errData;
-      data.type = type;
-      if (
-        type.name !== 'validation.html' ||
-        (type.name === 'validation.html' && !global.SKIP_VALIDATION)
-      ) {
-        errors = errors.push(data);
-      }
-    });
-
-    sink.on('exception', exception => {
-      reject(new Error(exception.message));
-    });
-
-     
-    (async () => {
-      const profile = stateMetadata.get('profile');
-      const patentPolicy = stateMetadata.get('patentPolicy');
-      if (
-        ['WD', 'CR', 'CRD'].includes(profile) ||
-        (profile === 'REC' && stateMetadata.get('recCandidateAmendments'))
-      ) {
-        specberusProfile = await import(
-          `specberus/lib/profiles/TR/Recommendation/${profile}-Echidna.js`
-        );
-      } else if (['NOTE', 'DNOTE'].includes(profile)) {
-        specberusProfile = await import(
-          `specberus/lib/profiles/TR/Note/${profile}-Echidna.js`
-        );
-      } else if (profile === 'DRY') {
-        specberusProfile = await import(
-          `specberus/lib/profiles/TR/Registry/${profile}-Echidna.js`
-        );
-      } else {
-        return reject(
-          new Error(
-            'Only WD, CR, CRD, REC with candidate amendments, DNOTE, NOTE and DRY are allowed!',
-          ),
-        );
-      }
-
-      const options = {
-        url,
-        profile: specberusProfile,
-        events: sink,
-      };
-
-      if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'test') {
-        const host = `http://localhost:${(process.env.PORT || 3000) + 1}`;
-        options.htmlValidator = `${host}/nu`;
-      }
-
-      const s = await SpecberusWrapper.getSpecberus();
-      s.validate(options);
-    })();
-  });
-
-SpecberusWrapper.extractMetadata = url =>
-  new Promise((resolve, reject) => {
-    function Sink() {}
-
-    util.inherits(Sink, EventEmitter);
-
-    const sink = new Sink();
-    let errors = new List();
-
-    sink.on('err', (type, data) => {
+  const sr = await SpecberusWrapper.getSpecberus();
+  sr.on('err', (type, errData) => {
+    const data = errData;
+    data.type = type;
+    if (
+      type.name !== 'validation.html' ||
+      (type.name === 'validation.html' && !global.SKIP_VALIDATION)
+    ) {
       errors = errors.push(data);
-    });
-
-    sink.on('end-all', data => {
-      resolve(data.metadata);
-    });
-
-    sink.on('exception', exception => {
-      reject(new Error(exception.message));
-    });
-
-    (async () => {
-      const Specberus = await import('specberus/lib/validator.js');
-      const s = new Specberus.Specberus();
-      s.extractMetadata({ url, events: sink });
-    })();
+    }
   });
+
+  return sr
+    .validate(options)
+    .then(({ metadata }) => ({ errors, metadata }));
+};
+
+SpecberusWrapper.extractMetadata = async url => {
+  const sr = await SpecberusWrapper.getSpecberus();
+  return sr
+    .extractMetadata({ url })
+    .then(({ metadata }) => metadata);
+};
 
 SpecberusWrapper.version = async () => {
-  const s = await SpecberusWrapper.getSpecberus();
-  return s.version;
+  const sr = await SpecberusWrapper.getSpecberus();
+  return sr.version;
 };
 
 export default SpecberusWrapper;

--- a/lib/specberus-wrapper.js
+++ b/lib/specberus-wrapper.js
@@ -22,7 +22,6 @@ SpecberusWrapper.validate = async (url, stateMetadata) => {
   let specberusProfile;
 
   const profile = stateMetadata.get('profile');
-  const patentPolicy = stateMetadata.get('patentPolicy');
   if (
     ['WD', 'CR', 'CRD'].includes(profile) ||
     (profile === 'REC' && stateMetadata.get('recCandidateAmendments'))

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "passport": "0.7.0",
     "passport-http": "0.3",
     "promise": "8.3.0",
-    "specberus": "12.3.0",
+    "specberus": "13.0.0",
     "superagent": "10.3.0",
     "tar-stream": "3.2.0",
     "uuid": "14.0.0"

--- a/test/test.js
+++ b/test/test.js
@@ -413,10 +413,10 @@ describe('SpecberusWrapper', () => {
     it('should promise an object with a metadata property', () =>
       expect(content).to.eventually.have.property('metadata'));
 
-    it('should return a metadata property that is a Map', () =>
+    it('should return a metadata property that is an object', () =>
       expect(content)
         .to.eventually.have.property('metadata')
-        .that.is.an.instanceOf(Map));
+        .that.is.an.instanceOf(Object));
   });
 
   describe('extractMetadata(url)', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,7 @@
 
 import * as chai from 'chai';
 import chaiAsPromised from '@rvagg/chai-as-promised';
-import Promise from 'promise';
+import ThenPromise from 'promise';
 import Fs from 'fs';
 import Immutable from 'immutable';
 
@@ -64,7 +64,7 @@ describe('DocumentDownloader', () => {
     const content = DocumentDownloader.fetch(server.location());
 
     it('should return a promise', () => {
-      expect(content).to.be.an.instanceOf(Promise);
+      expect(content).to.be.an.instanceOf(ThenPromise);
     });
 
     it('should promise a Buffer', () =>
@@ -103,7 +103,7 @@ describe('DocumentDownloader', () => {
     });
 
     it('should return a promise', () => {
-      expect(content).to.be.an.instanceOf(Promise);
+      expect(content).to.be.an.instanceOf(ThenPromise);
     });
 
     it('should promise a List of size 2', () =>
@@ -135,7 +135,7 @@ describe('DocumentDownloader', () => {
     });
 
     it('should return a promise', () =>
-      expect(promise).to.be.an.instanceOf(Promise));
+      expect(promise).to.be.an.instanceOf(ThenPromise));
 
     it('should create the file with proper content', () =>
       promise.then(() => {
@@ -165,7 +165,7 @@ describe('DocumentDownloader', () => {
     });
 
     it('should return a promise', () =>
-      expect(promise).to.be.an.instanceOf(Promise));
+      expect(promise).to.be.an.instanceOf(ThenPromise));
 
     it('should create multiple files with proper contents', () =>
       promise.then(() => {
@@ -218,7 +218,7 @@ describe('DocumentDownloader', () => {
     });
 
     it('should return a promise', () => {
-      expect(promise).to.be.an.instanceOf(Promise);
+      expect(promise).to.be.an.instanceOf(ThenPromise);
     });
 
     it('should create the folder if it does not exist', () =>
@@ -533,7 +533,7 @@ describe('TokenChecker', () => {
     const check = TokenChecker.check(myDraft.latestVersion, token, source);
 
     it('should return a promise', () => {
-      expect(check).to.be.an.instanceOf(Promise);
+      expect(check).to.be.an.instanceOf(ThenPromise);
     });
 
     it('should promise a list', () =>
@@ -561,7 +561,7 @@ describe('UserChecker', () => {
     const content = UserChecker.check(user, delivererIDs);
 
     it('should return a promise', () => {
-      expect(content).to.be.an.instanceOf(Promise);
+      expect(content).to.be.an.instanceOf(ThenPromise);
     });
 
     it('should promise a list', () =>
@@ -603,7 +603,7 @@ describe('IPChecker', () => {
     const check = IPChecker.check(badIp);
 
     it('should return a promise', () => {
-      expect(check).to.be.an.instanceOf(Promise);
+      expect(check).to.be.an.instanceOf(ThenPromise);
     });
 
     it('should promise a non-empty list', () =>
@@ -630,7 +630,7 @@ describe('Publisher', () => {
     const promise = new Publisher(new CreatedService()).publish(metadata);
 
     it('should return a promise', () => {
-      expect(promise).to.be.an.instanceOf(Promise);
+      expect(promise).to.be.an.instanceOf(ThenPromise);
     });
 
     it('should promise an array', () =>


### PR DESCRIPTION
This updates echidna to work with the [recently-released Specberus v13](https://github.com/w3c/specberus/releases/tag/v13.0.0).

Note that the `lib/specberus-wrapper.js` diff will be easier to view with whitespace ignored.

## Changes

- Use async functions and chain off of Specberus' own returned promises instead of needing to create and manage them manually
- Use returned promise instead of listening to `end-all` and `exception` events
- Use `.on` directly on Specberus instance (no more need for `sink`)
- Preserve existing `err` event handler logic in `validate`
- Remove `metadata` event handler (this event has not existed for a long time)
- Remove duplicated instantiation code in `extractMetadata`, instead reusing `getSpecberus`
- Remove completely unused `errors` variable from `extractMetadata`
- Update tests to expect native promises from `SpecberusWrapper` APIs