### PR TITLE
Update specberus to 13.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "passport": "0.7.0",
     "passport-http": "0.3",
     "promise": "8.3.0",
-    "specberus": "13.0.0",
+    "specberus": "13.0.3",
     "superagent": "10.3.0",
     "tar-stream": "3.2.0",
     "uuid": "14.0.0"


### PR DESCRIPTION
The purpose of this update is mainly to incorporate https://github.com/w3c/specberus/pull/2146.